### PR TITLE
Fix typing errors from TS and the Flow codegen template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: node_modules
 	# Generate the .d.ts files
 	node_modules/.bin/tsc --project tsconfig.json --checkJs false --emitDeclarationOnly || true
 	# TODO: Loop through everything in the lib folder to create the flow types
-	flowgen --add-flow-header lib/runtimeHelpers.d.ts --output-file lib/runtimeHelpers.js.flow
+	yarn flowgen --add-flow-header lib/runtimeHelpers.d.ts --output-file lib/runtimeHelpers.js.flow
 
 .PHONY: test
 test: build venv node_modules

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "files": [
     "lib",
     "schema.json"
-  ]
+  ],
+  "engines": {
+    "node": ">=10"
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ export interface GlobalConfig {
     resources: any;
 }
 
-interface BatchResourceConfig {
+export interface BatchResourceConfig {
     isBatchResource: true;
     batchKey: string;
     newKey: string;
@@ -27,7 +27,7 @@ interface BatchResourceConfig {
     isResponseDictionary?: boolean;
 }
 
-interface NonBatchResourceConfig {
+export interface NonBatchResourceConfig {
     isBatchResource: false;
 }
 

--- a/src/genTypeFlow.ts
+++ b/src/genTypeFlow.ts
@@ -63,7 +63,7 @@ export function getLoaderTypeVal(resourceConfig: ResourceConfig, resourcePath: R
         >`;
 
     if (resourceConfig.isBatchResource) {
-        retVal = `$ElementType<${retVal}, 0>`;
+        retVal = resourceConfig.isResponseDictionary ? `$Values<${retVal}>` : `$ElementType<${retVal}, 0>`;
     }
 
     /**

--- a/src/genTypeFlow.ts
+++ b/src/genTypeFlow.ts
@@ -14,7 +14,7 @@ const resourceReference = (resourcePath: ReadonlyArray<string>) => ['resources',
  */
 export function getResourceTypeReference(resourceConfig: ResourceConfig, resourcePath: ReadonlyArray<string>) {
     function toPropertyTypePath(path: ReadonlyArray<string>): string {
-        assert(path.length >= 1);
+        assert(path.length >= 1, 'expected resource path to be a not empty array');
 
         if (path.length === 1) {
             return path[0];

--- a/src/implementation.ts
+++ b/src/implementation.ts
@@ -1,4 +1,4 @@
-import { ResourceConfig } from './config';
+import { ResourceConfig, BatchResourceConfig, NonBatchResourceConfig } from './config';
 import assert from './assert';
 import { getLoaderTypeKey, getLoaderTypeVal } from './genTypeFlow';
 
@@ -27,7 +27,7 @@ function getLoaderComment(resourceConfig: ResourceConfig, resourcePath: Readonly
     `;
 }
 
-function getBatchLoader(resourceConfig: ResourceConfig, resourcePath: ReadonlyArray<string>) {
+function getBatchLoader(resourceConfig: BatchResourceConfig, resourcePath: ReadonlyArray<string>) {
     assert(
         resourceConfig.isBatchResource === true,
         `${errorPrefix(resourcePath)} Expected getBatchLoader to be called with a batch resource config`,
@@ -355,7 +355,7 @@ function getBatchLoader(resourceConfig: ResourceConfig, resourcePath: ReadonlyAr
      )`;
 }
 
-function getNonBatchLoader(resourceConfig: ResourceConfig, resourcePath: ReadonlyArray<string>) {
+function getNonBatchLoader(resourceConfig: NonBatchResourceConfig, resourcePath: ReadonlyArray<string>) {
     assert(
         resourceConfig.isBatchResource === false,
         `${errorPrefix(resourcePath)} Expected getNonBatchLoader to be called with a non-batch endpoint config`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import codegen from './codegen';
 import { getConfig } from './config';
 
 interface CLIArgs {
-    config?: string;
-    output?: string;
+    config: string;
+    output: string;
 }
 
 function writeLoaders(args: CLIArgs) {
@@ -17,6 +17,7 @@ function writeLoaders(args: CLIArgs) {
     const output = codegen(config);
 
     assert(typeof args.config === 'string', 'expected args.config to be set!');
+    assert(typeof args.output === 'string', 'expected args.output to be set!');
     fs.writeFileSync(args.output, output);
 }
 

--- a/src/runtimeHelpers.ts
+++ b/src/runtimeHelpers.ts
@@ -149,8 +149,9 @@ export function sortByKeys<V>({
 
             itemsMap.set(String(reorderResultsByValue), item);
         } else {
-            // TODO: Work how to tell typescript item[prop] exists
+            // @ts-ignore: TODO: Work how to tell typescript item[prop] exists
             invariant(item[prop] != null, `${errorPrefix(resourcePath)} Could not find property "${prop}" in item`);
+            // @ts-ignore: TODO: Work how to tell typescript item[prop] exists
             itemsMap.set(String(item[prop]), item);
         }
     });


### PR DESCRIPTION
Fix some issues about typings and build process

1. use `yarn flowgen` instead of `flowgen` in Makefile
2. add node version in `package.json`
3. fix TS error and use `@ts-ignore`
4. fix flow type error in `genFlowType.ts`