### PR TITLE
add make build to prepublish in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "jest",
     "build": "babel --verbose --extensions '.ts' src -d lib",
+    "prepublishOnly": "make build",
     "typecheck": "tsc --project tsconfig.json"
   },
   "bin": {


### PR DESCRIPTION
Well, if we look at https://travis-ci.com/github/Yelp/dataloader-codegen/builds/153277885 and https://travis-ci.com/github/Yelp/dataloader-codegen/builds/153254482#L374

The real problem of `v0.1.2` is we forget to add `prepublishOnly` entry in `package.json`,  `v0.1.3` accidentally fix it because we add the field `skip_cleanup` in `v0.1.3`, see https://docs.travis-ci.com/user/deployment/npm/#releasing-build-artifacts