### PR TITLE
fix flow type for nestedPath

### DIFF
--- a/examples/swapi/swapi-loaders.js
+++ b/examples/swapi/swapi-loaders.js
@@ -4,27 +4,27 @@
  * !!! THIS FILE IS AUTO-GENERATED. CHANGES MAY BE OVERWRITTEN !!!
  */
 
-import util from "util";
-import _ from "lodash";
-import invariant from "assert";
-import DataLoader from "dataloader";
+import util from 'util';
+import _ from 'lodash';
+import invariant from 'assert';
+import DataLoader from 'dataloader';
 import {
-  BatchItemNotFoundError,
-  cacheKeyOptions,
-  CaughtResourceError,
-  defaultErrorHandler,
-  partitionItems,
-  resultsDictToList,
-  sortByKeys,
-  unPartitionResults
-} from "dataloader-codegen/lib/runtimeHelpers";
+    BatchItemNotFoundError,
+    cacheKeyOptions,
+    CaughtResourceError,
+    defaultErrorHandler,
+    partitionItems,
+    resultsDictToList,
+    sortByKeys,
+    unPartitionResults,
+} from 'dataloader-codegen/lib/runtimeHelpers';
 
 /**
  * ===============================
  * BEGIN: printResourceTypeImports()
  * ===============================
  */
-import type { SWAPIClientlibTypes } from "./swapi";
+import type { SWAPIClientlibTypes } from './swapi';
 
 /**
  * ===============================
@@ -37,18 +37,15 @@ type ExtractArg = <Arg, Ret>([(Arg) => Ret]) => Arg;
 type ExtractPromisedReturnValue<A> = <R>((...A) => Promise<R>) => R;
 
 export type DataLoaderCodegenOptions = {|
-  errorHandler?: (
-    resourcePath: $ReadOnlyArray<string>,
-    // $FlowFixMe: We don't know what type the resource might throw, so we have to type error to "any" :(
-    error: any
-  ) => Promise<Error>,
-  resourceMiddleware?: {|
-    before?: <T>(
-      resourcePath: $ReadOnlyArray<string>,
-      resourceArgs: T
-    ) => Promise<T>,
-    after?: <T>(resourcePath: $ReadOnlyArray<string>, response: T) => Promise<T>
-  |}
+    errorHandler?: (
+        resourcePath: $ReadOnlyArray<string>,
+        // $FlowFixMe: We don't know what type the resource might throw, so we have to type error to "any" :(
+        error: any,
+    ) => Promise<Error>,
+    resourceMiddleware?: {|
+        before?: <T>(resourcePath: $ReadOnlyArray<string>, resourceArgs: T) => Promise<T>,
+        after?: <T>(resourcePath: $ReadOnlyArray<string>, response: T) => Promise<T>,
+    |},
 |};
 
 /**
@@ -65,1843 +62,1662 @@ type ResourcesType = SWAPIClientlibTypes;
  */
 
 export type LoadersType = $ReadOnly<{|
-  getPlanets: DataLoader<
-    {|
-      ...$Diff<
-        $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
-        {
-          planet_ids: $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
-            "planet_ids"
-          >
-        }
-      >,
-      ...{|
-        planet_id: $ElementType<
-          $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
-            "planet_ids"
-          >,
-          0
-        >
-      |}
-    |},
-    $ElementType<
-      $Call<
-        ExtractPromisedReturnValue<
-          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>]
+    getPlanets: DataLoader<
+        {|
+            ...$Diff<
+                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
+                {
+                    planet_ids: $PropertyType<
+                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
+                        'planet_ids',
+                    >,
+                },
+            >,
+            ...{|
+                planet_id: $ElementType<
+                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>, 'planet_ids'>,
+                    0,
+                >,
+            |},
+        |},
+        $ElementType<
+            $Call<
+                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>]>,
+                $PropertyType<ResourcesType, 'getPlanets'>,
+            >,
+            0,
         >,
-        $PropertyType<ResourcesType, "getPlanets">
-      >,
-      0
+        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+        string,
     >,
-    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-    string
-  >,
-  getPeople: DataLoader<
-    {|
-      ...$Diff<
-        $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
-        {
-          people_ids: $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
-            "people_ids"
-          >
-        }
-      >,
-      ...{|
-        person_id: $ElementType<
-          $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
-            "people_ids"
-          >,
-          0
-        >
-      |}
-    |},
-    $ElementType<
-      $Call<
-        ExtractPromisedReturnValue<
-          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>]
+    getPeople: DataLoader<
+        {|
+            ...$Diff<
+                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
+                {
+                    people_ids: $PropertyType<
+                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
+                        'people_ids',
+                    >,
+                },
+            >,
+            ...{|
+                person_id: $ElementType<
+                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>, 'people_ids'>,
+                    0,
+                >,
+            |},
+        |},
+        $ElementType<
+            $Call<
+                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>]>,
+                $PropertyType<ResourcesType, 'getPeople'>,
+            >,
+            0,
         >,
-        $PropertyType<ResourcesType, "getPeople">
-      >,
-      0
+        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+        string,
     >,
-    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-    string
-  >,
-  getVehicles: DataLoader<
-    {|
-      ...$Diff<
-        $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
-        {
-          vehicle_ids: $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
-            "vehicle_ids"
-          >
-        }
-      >,
-      ...{|
-        vehicle_id: $ElementType<
-          $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
-            "vehicle_ids"
-          >,
-          0
-        >
-      |}
-    |},
-    $ElementType<
-      $Call<
-        ExtractPromisedReturnValue<
-          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>]
+    getVehicles: DataLoader<
+        {|
+            ...$Diff<
+                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
+                {
+                    vehicle_ids: $PropertyType<
+                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
+                        'vehicle_ids',
+                    >,
+                },
+            >,
+            ...{|
+                vehicle_id: $ElementType<
+                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>, 'vehicle_ids'>,
+                    0,
+                >,
+            |},
+        |},
+        $ElementType<
+            $Call<
+                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>]>,
+                $PropertyType<ResourcesType, 'getVehicles'>,
+            >,
+            0,
         >,
-        $PropertyType<ResourcesType, "getVehicles">
-      >,
-      0
+        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+        string,
     >,
-    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-    string
-  >,
-  getFilms: DataLoader<
-    {|
-      ...$Diff<
-        $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
-        {
-          film_ids: $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
-            "film_ids"
-          >
-        }
-      >,
-      ...{|
-        film_id: $Call<
-          ExtractArg,
-          [
+    getFilms: DataLoader<
+        {|
+            ...$Diff<
+                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
+                {
+                    film_ids: $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>, 'film_ids'>,
+                },
+            >,
+            ...{|
+                film_id: $Call<
+                    ExtractArg,
+                    [
+                        $PropertyType<
+                            $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>, 'film_ids'>,
+                            'has',
+                        >,
+                    ],
+                >,
+            |},
+        |},
+        $ElementType<
+            $Call<
+                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>]>,
+                $PropertyType<ResourcesType, 'getFilms'>,
+            >,
+            0,
+        >,
+        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+        string,
+    >,
+    getFilmsV2: DataLoader<
+        {|
+            ...$Diff<
+                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>,
+                {
+                    film_ids: $PropertyType<
+                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>,
+                        'film_ids',
+                    >,
+                },
+            >,
+            ...{|
+                film_id: $ElementType<
+                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>, 'film_ids'>,
+                    0,
+                >,
+            |},
+        |},
+        $ElementType<
             $PropertyType<
-              $PropertyType<
-                $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
-                "film_ids"
-              >,
-              "has"
-            >
-          ]
-        >
-      |}
-    |},
-    $ElementType<
-      $Call<
-        ExtractPromisedReturnValue<
-          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>]
+                $Call<
+                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>]>,
+                    $PropertyType<ResourcesType, 'getFilmsV2'>,
+                >,
+                'properties',
+            >,
+            0,
         >,
-        $PropertyType<ResourcesType, "getFilms">
-      >,
-      0
+        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+        string,
     >,
-    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-    string
-  >,
-  getFilmsV2: DataLoader<
-    {|
-      ...$Diff<
-        $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
-        {
-          film_ids: $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
-            "film_ids"
-          >
-        }
-      >,
-      ...{|
-        film_id: $ElementType<
-          $PropertyType<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
-            "film_ids"
-          >,
-          0
-        >
-      |}
-    |},
-    $ElementType<
-      $PropertyType<
+    getRoot: DataLoader<
+        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>,
         $Call<
-          ExtractPromisedReturnValue<
-            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>]
-          >,
-          $PropertyType<ResourcesType, "getFilmsV2">
+            ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>]>,
+            $PropertyType<ResourcesType, 'getRoot'>,
         >,
-        "properties"
-      >,
-      0
+        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+        string,
     >,
-    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-    string
-  >,
-  getRoot: DataLoader<
-    $Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>,
-    $Call<
-      ExtractPromisedReturnValue<
-        [$Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>]
-      >,
-      $PropertyType<ResourcesType, "getRoot">
-    >,
-    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-    string
-  >
 |}>;
 
-export default function getLoaders(
-  resources: ResourcesType,
-  options?: DataLoaderCodegenOptions
-): LoadersType {
-  return Object.freeze({
-    getPlanets: new DataLoader<
-      {|
-        ...$Diff<
-          $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
-          {
-            planet_ids: $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
-              "planet_ids"
-            >
-          }
-        >,
-        ...{|
-          planet_id: $ElementType<
-            $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
-              "planet_ids"
-            >,
-            0
-          >
-        |}
-      |},
-      $ElementType<
-        $Call<
-          ExtractPromisedReturnValue<
-            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>]
-          >,
-          $PropertyType<ResourcesType, "getPlanets">
-        >,
-        0
-      >,
-      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-      string
-    >(
-      /**
-       * ===============================================================
-       * Generated DataLoader: getPlanets
-       * ===============================================================
-       *
-       * Resource Config:
-       *
-       * ```json
-       * {
-       *   "docsLink": "https://swapi.dev/documentation#planets",
-       *   "isBatchResource": true,
-       *   "batchKey": "planet_ids",
-       *   "newKey": "planet_id"
-       * }
-       * ```
-       */
-      async keys => {
-        invariant(
-          typeof resources.getPlanets === "function",
-          [
-            "[dataloader-codegen :: getPlanets] resources.getPlanets is not a function.",
-            'Did you pass in an instance of getPlanets to "getLoaders"?'
-          ].join(" ")
-        );
-
-        /**
-         * Chunk up the "keys" array to create a set of "request groups".
-         *
-         * We're about to hit a batch resource. In addition to the batch
-         * key, the resource may take other arguments too. When batching
-         * up requests, we'll want to look out for where those other
-         * arguments differ, and send multiple requests so we don't get
-         * back the wrong info.
-         *
-         * In other words, we'll potentially want to send _multiple_
-         * requests to the underlying resource batch method in this
-         * dataloader body.
-         *
-         * ~~~ Why? ~~~
-         *
-         * Consider what happens when we get called with arguments where
-         * the non-batch keys differ.
-         *
-         * Example:
-         *
-         * ```js
-         * loaders.foo.load({ foo_id: 2, include_private_data: true });
-         * loaders.foo.load({ foo_id: 3, include_private_data: false });
-         * loaders.foo.load({ foo_id: 4, include_private_data: false });
-         * ```
-         *
-         * If we collected everything up and tried to send the one
-         * request to the resource as a batch request, how do we know
-         * what the value for "include_private_data" should be? We're
-         * going to have to group these up up and send two requests to
-         * the resource to make sure we're requesting the right stuff.
-         *
-         * e.g. We'd need to make the following set of underlying resource
-         * calls:
-         *
-         * ```js
-         * foo({ foo_ids: [ 2 ], include_private_data: true });
-         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-         * ```
-         *
-         * ~~~ tl;dr ~~~
-         *
-         * When we have calls to .load with differing non batch key args,
-         * we'll need to send multiple requests to the underlying
-         * resource to make sure we get the right results back.
-         *
-         * Let's create the request groups, where each element in the
-         * group refers to a position in "keys" (i.e. a call to .load)
-         *
-         * Example:
-         *
-         * ```js
-         * partitionItems([
-         *   { bar_id: 7, include_extra_info: true },
-         *   { bar_id: 8, include_extra_info: false },
-         *   { bar_id: 9, include_extra_info: true },
-         * ], 'bar_id')
-         * ```
-         *
-         * Returns:
-         * `[ [ 0, 2 ], [ 1 ] ]`
-         *
-         * We'll refer to each element in the group as a "request ID".
-         */
-        const requestGroups = partitionItems("planet_id", keys);
-
-        // Map the request groups to a list of Promises - one for each request
-        const groupedResults = await Promise.all(
-          requestGroups.map(async requestIDs => {
-            /**
-             * Select a set of elements in "keys", where all non-batch
-             * keys should be identical.
-             *
-             * We're going to smoosh all these together into one payload to
-             * send to the resource as a batch request!
-             */
-            const requests = requestIDs.map(id => keys[id]);
-
-            // For now, we assume that the dataloader key should be the first argument to the resource
-            // @see https://github.com/Yelp/dataloader-codegen/issues/56
-            const resourceArgs = [
-              {
-                ..._.omit(requests[0], "planet_id"),
-                ["planet_ids"]: requests.map(k => k["planet_id"])
-              }
-            ];
-
-            let response = await (async _resourceArgs => {
-              // Make a re-assignable variable so flow/eslint doesn't complain
-              let __resourceArgs = _resourceArgs;
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.before
-              ) {
-                __resourceArgs = await options.resourceMiddleware.before(
-                  ["getPlanets"],
-                  __resourceArgs
-                );
-              }
-
-              let _response;
-              try {
-                // Finally, call the resource!
-                _response = await resources.getPlanets(...__resourceArgs);
-              } catch (error) {
-                const errorHandler =
-                  options && typeof options.errorHandler === "function"
-                    ? options.errorHandler
-                    : defaultErrorHandler;
-
-                /**
-                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                 *
-                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                 */
-                _response = await errorHandler(["getPlanets"], error);
-
-                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                if (!(_response instanceof Error)) {
-                  _response = new Error(
-                    [
-                      `[dataloader-codegen :: getPlanets] Caught an error, but errorHandler did not return an Error object.`,
-                      `Instead, got ${typeof _response}: ${util.inspect(
-                        _response
-                      )}`
-                    ].join(" ")
-                  );
-                }
-              }
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.after
-              ) {
-                _response = await options.resourceMiddleware.after(
-                  ["getPlanets"],
-                  _response
-                );
-              }
-
-              return _response;
-            })(resourceArgs);
-
-            if (!(response instanceof Error)) {
-            }
-
-            if (!(response instanceof Error)) {
-              if (!Array.isArray(response)) {
-                response = new Error(
-                  [
-                    "[dataloader-codegen :: getPlanets]",
-                    "Expected response to be an array!"
-                  ].join(" ")
-                );
-              }
-            }
-
-            if (!(response instanceof Error)) {
-              /**
-               * Check to see the resource contains the same number
-               * of items that we requested. If not, since there's
-               * no "reorderResultsByKey" specified for this resource,
-               * we don't know _which_ key's response is missing. Therefore
-               * it's unsafe to return the response array back.
-               */
-              if (response.length !== requests.length) {
-                /**
-                 * We must return errors for all keys in this group :(
-                 */
-                response = new BatchItemNotFoundError(
-                  [
-                    `[dataloader-codegen :: getPlanets] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
-                  ].join(" ")
-                );
-
-                // Tell flow that BatchItemNotFoundError extends Error.
-                // It's an issue with flowgen package, but not an issue with Flow.
-                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                invariant(
-                  response instanceof Error,
-                  "expected BatchItemNotFoundError to be an Error"
-                );
-              }
-            }
-
-            /**
-             * If the resource returns an Error, we'll want to copy and
-             * return that error as the return value for every request in
-             * this group.
-             *
-             * This allow the error to be cached, and allows the rest of the
-             * requests made by this DataLoader to succeed.
-             *
-             * @see https://github.com/graphql/dataloader#caching-errors
-             */
-            if (response instanceof Error) {
-              response = requestIDs.map(requestId => {
-                /**
-                 * Since we're returning an error object and not the
-                 * expected return type from the resource, this element
-                 * would be unsortable, since it wouldn't have the
-                 * "reorderResultsByKey" attribute.
-                 *
-                 * Let's add it to the error object, as "reorderResultsByValue".
-                 *
-                 * (If we didn't specify that this resource needs
-                 * sorting, then this will be "null" and won't be used.)
-                 */
-                const reorderResultsByValue = null;
-
-                // Tell flow that "response" is actually an error object.
-                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                invariant(
-                  response instanceof Error,
-                  "expected response to be an error"
-                );
-
-                return new CaughtResourceError(
-                  `[dataloader-codegen :: getPlanets] Caught error during call to resource. Error: ${response.stack}`,
-                  response,
-                  reorderResultsByValue
-                );
-              });
-            }
-
-            return response;
-          })
-        );
-
-        // Split the results back up into the order that they were requested
-        return unPartitionResults(requestGroups, groupedResults);
-      },
-      {
-        ...cacheKeyOptions
-      }
-    ),
-    getPeople: new DataLoader<
-      {|
-        ...$Diff<
-          $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
-          {
-            people_ids: $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
-              "people_ids"
-            >
-          }
-        >,
-        ...{|
-          person_id: $ElementType<
-            $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
-              "people_ids"
-            >,
-            0
-          >
-        |}
-      |},
-      $ElementType<
-        $Call<
-          ExtractPromisedReturnValue<
-            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>]
-          >,
-          $PropertyType<ResourcesType, "getPeople">
-        >,
-        0
-      >,
-      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-      string
-    >(
-      /**
-       * ===============================================================
-       * Generated DataLoader: getPeople
-       * ===============================================================
-       *
-       * Resource Config:
-       *
-       * ```json
-       * {
-       *   "docsLink": "https://swapi.dev/documentation#people",
-       *   "isBatchResource": true,
-       *   "batchKey": "people_ids",
-       *   "newKey": "person_id"
-       * }
-       * ```
-       */
-      async keys => {
-        invariant(
-          typeof resources.getPeople === "function",
-          [
-            "[dataloader-codegen :: getPeople] resources.getPeople is not a function.",
-            'Did you pass in an instance of getPeople to "getLoaders"?'
-          ].join(" ")
-        );
-
-        /**
-         * Chunk up the "keys" array to create a set of "request groups".
-         *
-         * We're about to hit a batch resource. In addition to the batch
-         * key, the resource may take other arguments too. When batching
-         * up requests, we'll want to look out for where those other
-         * arguments differ, and send multiple requests so we don't get
-         * back the wrong info.
-         *
-         * In other words, we'll potentially want to send _multiple_
-         * requests to the underlying resource batch method in this
-         * dataloader body.
-         *
-         * ~~~ Why? ~~~
-         *
-         * Consider what happens when we get called with arguments where
-         * the non-batch keys differ.
-         *
-         * Example:
-         *
-         * ```js
-         * loaders.foo.load({ foo_id: 2, include_private_data: true });
-         * loaders.foo.load({ foo_id: 3, include_private_data: false });
-         * loaders.foo.load({ foo_id: 4, include_private_data: false });
-         * ```
-         *
-         * If we collected everything up and tried to send the one
-         * request to the resource as a batch request, how do we know
-         * what the value for "include_private_data" should be? We're
-         * going to have to group these up up and send two requests to
-         * the resource to make sure we're requesting the right stuff.
-         *
-         * e.g. We'd need to make the following set of underlying resource
-         * calls:
-         *
-         * ```js
-         * foo({ foo_ids: [ 2 ], include_private_data: true });
-         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-         * ```
-         *
-         * ~~~ tl;dr ~~~
-         *
-         * When we have calls to .load with differing non batch key args,
-         * we'll need to send multiple requests to the underlying
-         * resource to make sure we get the right results back.
-         *
-         * Let's create the request groups, where each element in the
-         * group refers to a position in "keys" (i.e. a call to .load)
-         *
-         * Example:
-         *
-         * ```js
-         * partitionItems([
-         *   { bar_id: 7, include_extra_info: true },
-         *   { bar_id: 8, include_extra_info: false },
-         *   { bar_id: 9, include_extra_info: true },
-         * ], 'bar_id')
-         * ```
-         *
-         * Returns:
-         * `[ [ 0, 2 ], [ 1 ] ]`
-         *
-         * We'll refer to each element in the group as a "request ID".
-         */
-        const requestGroups = partitionItems("person_id", keys);
-
-        // Map the request groups to a list of Promises - one for each request
-        const groupedResults = await Promise.all(
-          requestGroups.map(async requestIDs => {
-            /**
-             * Select a set of elements in "keys", where all non-batch
-             * keys should be identical.
-             *
-             * We're going to smoosh all these together into one payload to
-             * send to the resource as a batch request!
-             */
-            const requests = requestIDs.map(id => keys[id]);
-
-            // For now, we assume that the dataloader key should be the first argument to the resource
-            // @see https://github.com/Yelp/dataloader-codegen/issues/56
-            const resourceArgs = [
-              {
-                ..._.omit(requests[0], "person_id"),
-                ["people_ids"]: requests.map(k => k["person_id"])
-              }
-            ];
-
-            let response = await (async _resourceArgs => {
-              // Make a re-assignable variable so flow/eslint doesn't complain
-              let __resourceArgs = _resourceArgs;
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.before
-              ) {
-                __resourceArgs = await options.resourceMiddleware.before(
-                  ["getPeople"],
-                  __resourceArgs
-                );
-              }
-
-              let _response;
-              try {
-                // Finally, call the resource!
-                _response = await resources.getPeople(...__resourceArgs);
-              } catch (error) {
-                const errorHandler =
-                  options && typeof options.errorHandler === "function"
-                    ? options.errorHandler
-                    : defaultErrorHandler;
-
-                /**
-                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                 *
-                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                 */
-                _response = await errorHandler(["getPeople"], error);
-
-                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                if (!(_response instanceof Error)) {
-                  _response = new Error(
-                    [
-                      `[dataloader-codegen :: getPeople] Caught an error, but errorHandler did not return an Error object.`,
-                      `Instead, got ${typeof _response}: ${util.inspect(
-                        _response
-                      )}`
-                    ].join(" ")
-                  );
-                }
-              }
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.after
-              ) {
-                _response = await options.resourceMiddleware.after(
-                  ["getPeople"],
-                  _response
-                );
-              }
-
-              return _response;
-            })(resourceArgs);
-
-            if (!(response instanceof Error)) {
-            }
-
-            if (!(response instanceof Error)) {
-              if (!Array.isArray(response)) {
-                response = new Error(
-                  [
-                    "[dataloader-codegen :: getPeople]",
-                    "Expected response to be an array!"
-                  ].join(" ")
-                );
-              }
-            }
-
-            if (!(response instanceof Error)) {
-              /**
-               * Check to see the resource contains the same number
-               * of items that we requested. If not, since there's
-               * no "reorderResultsByKey" specified for this resource,
-               * we don't know _which_ key's response is missing. Therefore
-               * it's unsafe to return the response array back.
-               */
-              if (response.length !== requests.length) {
-                /**
-                 * We must return errors for all keys in this group :(
-                 */
-                response = new BatchItemNotFoundError(
-                  [
-                    `[dataloader-codegen :: getPeople] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
-                  ].join(" ")
-                );
-
-                // Tell flow that BatchItemNotFoundError extends Error.
-                // It's an issue with flowgen package, but not an issue with Flow.
-                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                invariant(
-                  response instanceof Error,
-                  "expected BatchItemNotFoundError to be an Error"
-                );
-              }
-            }
-
-            /**
-             * If the resource returns an Error, we'll want to copy and
-             * return that error as the return value for every request in
-             * this group.
-             *
-             * This allow the error to be cached, and allows the rest of the
-             * requests made by this DataLoader to succeed.
-             *
-             * @see https://github.com/graphql/dataloader#caching-errors
-             */
-            if (response instanceof Error) {
-              response = requestIDs.map(requestId => {
-                /**
-                 * Since we're returning an error object and not the
-                 * expected return type from the resource, this element
-                 * would be unsortable, since it wouldn't have the
-                 * "reorderResultsByKey" attribute.
-                 *
-                 * Let's add it to the error object, as "reorderResultsByValue".
-                 *
-                 * (If we didn't specify that this resource needs
-                 * sorting, then this will be "null" and won't be used.)
-                 */
-                const reorderResultsByValue = null;
-
-                // Tell flow that "response" is actually an error object.
-                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                invariant(
-                  response instanceof Error,
-                  "expected response to be an error"
-                );
-
-                return new CaughtResourceError(
-                  `[dataloader-codegen :: getPeople] Caught error during call to resource. Error: ${response.stack}`,
-                  response,
-                  reorderResultsByValue
-                );
-              });
-            }
-
-            return response;
-          })
-        );
-
-        // Split the results back up into the order that they were requested
-        return unPartitionResults(requestGroups, groupedResults);
-      },
-      {
-        ...cacheKeyOptions
-      }
-    ),
-    getVehicles: new DataLoader<
-      {|
-        ...$Diff<
-          $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
-          {
-            vehicle_ids: $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
-              "vehicle_ids"
-            >
-          }
-        >,
-        ...{|
-          vehicle_id: $ElementType<
-            $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
-              "vehicle_ids"
-            >,
-            0
-          >
-        |}
-      |},
-      $ElementType<
-        $Call<
-          ExtractPromisedReturnValue<
-            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>]
-          >,
-          $PropertyType<ResourcesType, "getVehicles">
-        >,
-        0
-      >,
-      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-      string
-    >(
-      /**
-       * ===============================================================
-       * Generated DataLoader: getVehicles
-       * ===============================================================
-       *
-       * Resource Config:
-       *
-       * ```json
-       * {
-       *   "docsLink": "https://swapi.dev/documentation#vehicles",
-       *   "isBatchResource": true,
-       *   "batchKey": "vehicle_ids",
-       *   "newKey": "vehicle_id"
-       * }
-       * ```
-       */
-      async keys => {
-        invariant(
-          typeof resources.getVehicles === "function",
-          [
-            "[dataloader-codegen :: getVehicles] resources.getVehicles is not a function.",
-            'Did you pass in an instance of getVehicles to "getLoaders"?'
-          ].join(" ")
-        );
-
-        /**
-         * Chunk up the "keys" array to create a set of "request groups".
-         *
-         * We're about to hit a batch resource. In addition to the batch
-         * key, the resource may take other arguments too. When batching
-         * up requests, we'll want to look out for where those other
-         * arguments differ, and send multiple requests so we don't get
-         * back the wrong info.
-         *
-         * In other words, we'll potentially want to send _multiple_
-         * requests to the underlying resource batch method in this
-         * dataloader body.
-         *
-         * ~~~ Why? ~~~
-         *
-         * Consider what happens when we get called with arguments where
-         * the non-batch keys differ.
-         *
-         * Example:
-         *
-         * ```js
-         * loaders.foo.load({ foo_id: 2, include_private_data: true });
-         * loaders.foo.load({ foo_id: 3, include_private_data: false });
-         * loaders.foo.load({ foo_id: 4, include_private_data: false });
-         * ```
-         *
-         * If we collected everything up and tried to send the one
-         * request to the resource as a batch request, how do we know
-         * what the value for "include_private_data" should be? We're
-         * going to have to group these up up and send two requests to
-         * the resource to make sure we're requesting the right stuff.
-         *
-         * e.g. We'd need to make the following set of underlying resource
-         * calls:
-         *
-         * ```js
-         * foo({ foo_ids: [ 2 ], include_private_data: true });
-         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-         * ```
-         *
-         * ~~~ tl;dr ~~~
-         *
-         * When we have calls to .load with differing non batch key args,
-         * we'll need to send multiple requests to the underlying
-         * resource to make sure we get the right results back.
-         *
-         * Let's create the request groups, where each element in the
-         * group refers to a position in "keys" (i.e. a call to .load)
-         *
-         * Example:
-         *
-         * ```js
-         * partitionItems([
-         *   { bar_id: 7, include_extra_info: true },
-         *   { bar_id: 8, include_extra_info: false },
-         *   { bar_id: 9, include_extra_info: true },
-         * ], 'bar_id')
-         * ```
-         *
-         * Returns:
-         * `[ [ 0, 2 ], [ 1 ] ]`
-         *
-         * We'll refer to each element in the group as a "request ID".
-         */
-        const requestGroups = partitionItems("vehicle_id", keys);
-
-        // Map the request groups to a list of Promises - one for each request
-        const groupedResults = await Promise.all(
-          requestGroups.map(async requestIDs => {
-            /**
-             * Select a set of elements in "keys", where all non-batch
-             * keys should be identical.
-             *
-             * We're going to smoosh all these together into one payload to
-             * send to the resource as a batch request!
-             */
-            const requests = requestIDs.map(id => keys[id]);
-
-            // For now, we assume that the dataloader key should be the first argument to the resource
-            // @see https://github.com/Yelp/dataloader-codegen/issues/56
-            const resourceArgs = [
-              {
-                ..._.omit(requests[0], "vehicle_id"),
-                ["vehicle_ids"]: requests.map(k => k["vehicle_id"])
-              }
-            ];
-
-            let response = await (async _resourceArgs => {
-              // Make a re-assignable variable so flow/eslint doesn't complain
-              let __resourceArgs = _resourceArgs;
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.before
-              ) {
-                __resourceArgs = await options.resourceMiddleware.before(
-                  ["getVehicles"],
-                  __resourceArgs
-                );
-              }
-
-              let _response;
-              try {
-                // Finally, call the resource!
-                _response = await resources.getVehicles(...__resourceArgs);
-              } catch (error) {
-                const errorHandler =
-                  options && typeof options.errorHandler === "function"
-                    ? options.errorHandler
-                    : defaultErrorHandler;
-
-                /**
-                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                 *
-                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                 */
-                _response = await errorHandler(["getVehicles"], error);
-
-                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                if (!(_response instanceof Error)) {
-                  _response = new Error(
-                    [
-                      `[dataloader-codegen :: getVehicles] Caught an error, but errorHandler did not return an Error object.`,
-                      `Instead, got ${typeof _response}: ${util.inspect(
-                        _response
-                      )}`
-                    ].join(" ")
-                  );
-                }
-              }
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.after
-              ) {
-                _response = await options.resourceMiddleware.after(
-                  ["getVehicles"],
-                  _response
-                );
-              }
-
-              return _response;
-            })(resourceArgs);
-
-            if (!(response instanceof Error)) {
-            }
-
-            if (!(response instanceof Error)) {
-              if (!Array.isArray(response)) {
-                response = new Error(
-                  [
-                    "[dataloader-codegen :: getVehicles]",
-                    "Expected response to be an array!"
-                  ].join(" ")
-                );
-              }
-            }
-
-            if (!(response instanceof Error)) {
-              /**
-               * Check to see the resource contains the same number
-               * of items that we requested. If not, since there's
-               * no "reorderResultsByKey" specified for this resource,
-               * we don't know _which_ key's response is missing. Therefore
-               * it's unsafe to return the response array back.
-               */
-              if (response.length !== requests.length) {
-                /**
-                 * We must return errors for all keys in this group :(
-                 */
-                response = new BatchItemNotFoundError(
-                  [
-                    `[dataloader-codegen :: getVehicles] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
-                  ].join(" ")
-                );
-
-                // Tell flow that BatchItemNotFoundError extends Error.
-                // It's an issue with flowgen package, but not an issue with Flow.
-                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                invariant(
-                  response instanceof Error,
-                  "expected BatchItemNotFoundError to be an Error"
-                );
-              }
-            }
-
-            /**
-             * If the resource returns an Error, we'll want to copy and
-             * return that error as the return value for every request in
-             * this group.
-             *
-             * This allow the error to be cached, and allows the rest of the
-             * requests made by this DataLoader to succeed.
-             *
-             * @see https://github.com/graphql/dataloader#caching-errors
-             */
-            if (response instanceof Error) {
-              response = requestIDs.map(requestId => {
-                /**
-                 * Since we're returning an error object and not the
-                 * expected return type from the resource, this element
-                 * would be unsortable, since it wouldn't have the
-                 * "reorderResultsByKey" attribute.
-                 *
-                 * Let's add it to the error object, as "reorderResultsByValue".
-                 *
-                 * (If we didn't specify that this resource needs
-                 * sorting, then this will be "null" and won't be used.)
-                 */
-                const reorderResultsByValue = null;
-
-                // Tell flow that "response" is actually an error object.
-                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                invariant(
-                  response instanceof Error,
-                  "expected response to be an error"
-                );
-
-                return new CaughtResourceError(
-                  `[dataloader-codegen :: getVehicles] Caught error during call to resource. Error: ${response.stack}`,
-                  response,
-                  reorderResultsByValue
-                );
-              });
-            }
-
-            return response;
-          })
-        );
-
-        // Split the results back up into the order that they were requested
-        return unPartitionResults(requestGroups, groupedResults);
-      },
-      {
-        ...cacheKeyOptions
-      }
-    ),
-    getFilms: new DataLoader<
-      {|
-        ...$Diff<
-          $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
-          {
-            film_ids: $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
-              "film_ids"
-            >
-          }
-        >,
-        ...{|
-          film_id: $Call<
-            ExtractArg,
-            [
-              $PropertyType<
-                $PropertyType<
-                  $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
-                  "film_ids"
+export default function getLoaders(resources: ResourcesType, options?: DataLoaderCodegenOptions): LoadersType {
+    return Object.freeze({
+        getPlanets: new DataLoader<
+            {|
+                ...$Diff<
+                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
+                    {
+                        planet_ids: $PropertyType<
+                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
+                            'planet_ids',
+                        >,
+                    },
                 >,
-                "has"
-              >
-            ]
-          >
-        |}
-      |},
-      $ElementType<
-        $Call<
-          ExtractPromisedReturnValue<
-            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>]
-          >,
-          $PropertyType<ResourcesType, "getFilms">
-        >,
-        0
-      >,
-      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-      string
-    >(
-      /**
-       * ===============================================================
-       * Generated DataLoader: getFilms
-       * ===============================================================
-       *
-       * Resource Config:
-       *
-       * ```json
-       * {
-       *   "docsLink": "https://swapi.dev/documentation#films",
-       *   "isBatchResource": true,
-       *   "batchKey": "film_ids",
-       *   "newKey": "film_id",
-       *   "isBatchKeyASet": true
-       * }
-       * ```
-       */
-      async keys => {
-        invariant(
-          typeof resources.getFilms === "function",
-          [
-            "[dataloader-codegen :: getFilms] resources.getFilms is not a function.",
-            'Did you pass in an instance of getFilms to "getLoaders"?'
-          ].join(" ")
-        );
-
-        /**
-         * Chunk up the "keys" array to create a set of "request groups".
-         *
-         * We're about to hit a batch resource. In addition to the batch
-         * key, the resource may take other arguments too. When batching
-         * up requests, we'll want to look out for where those other
-         * arguments differ, and send multiple requests so we don't get
-         * back the wrong info.
-         *
-         * In other words, we'll potentially want to send _multiple_
-         * requests to the underlying resource batch method in this
-         * dataloader body.
-         *
-         * ~~~ Why? ~~~
-         *
-         * Consider what happens when we get called with arguments where
-         * the non-batch keys differ.
-         *
-         * Example:
-         *
-         * ```js
-         * loaders.foo.load({ foo_id: 2, include_private_data: true });
-         * loaders.foo.load({ foo_id: 3, include_private_data: false });
-         * loaders.foo.load({ foo_id: 4, include_private_data: false });
-         * ```
-         *
-         * If we collected everything up and tried to send the one
-         * request to the resource as a batch request, how do we know
-         * what the value for "include_private_data" should be? We're
-         * going to have to group these up up and send two requests to
-         * the resource to make sure we're requesting the right stuff.
-         *
-         * e.g. We'd need to make the following set of underlying resource
-         * calls:
-         *
-         * ```js
-         * foo({ foo_ids: [ 2 ], include_private_data: true });
-         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-         * ```
-         *
-         * ~~~ tl;dr ~~~
-         *
-         * When we have calls to .load with differing non batch key args,
-         * we'll need to send multiple requests to the underlying
-         * resource to make sure we get the right results back.
-         *
-         * Let's create the request groups, where each element in the
-         * group refers to a position in "keys" (i.e. a call to .load)
-         *
-         * Example:
-         *
-         * ```js
-         * partitionItems([
-         *   { bar_id: 7, include_extra_info: true },
-         *   { bar_id: 8, include_extra_info: false },
-         *   { bar_id: 9, include_extra_info: true },
-         * ], 'bar_id')
-         * ```
-         *
-         * Returns:
-         * `[ [ 0, 2 ], [ 1 ] ]`
-         *
-         * We'll refer to each element in the group as a "request ID".
-         */
-        const requestGroups = partitionItems("film_id", keys);
-
-        // Map the request groups to a list of Promises - one for each request
-        const groupedResults = await Promise.all(
-          requestGroups.map(async requestIDs => {
-            /**
-             * Select a set of elements in "keys", where all non-batch
-             * keys should be identical.
-             *
-             * We're going to smoosh all these together into one payload to
-             * send to the resource as a batch request!
-             */
-            const requests = requestIDs.map(id => keys[id]);
-
-            // For now, we assume that the dataloader key should be the first argument to the resource
-            // @see https://github.com/Yelp/dataloader-codegen/issues/56
-            const resourceArgs = [
-              {
-                ..._.omit(requests[0], "film_id"),
-                ["film_ids"]: requests.map(k => k["film_id"])
-              }
-            ];
-
-            let response = await (async _resourceArgs => {
-              // Make a re-assignable variable so flow/eslint doesn't complain
-              let __resourceArgs = _resourceArgs;
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.before
-              ) {
-                __resourceArgs = await options.resourceMiddleware.before(
-                  ["getFilms"],
-                  __resourceArgs
-                );
-              }
-
-              let _response;
-              try {
-                // Finally, call the resource!
-                _response = await resources.getFilms(...__resourceArgs);
-              } catch (error) {
-                const errorHandler =
-                  options && typeof options.errorHandler === "function"
-                    ? options.errorHandler
-                    : defaultErrorHandler;
-
-                /**
-                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                 *
-                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                 */
-                _response = await errorHandler(["getFilms"], error);
-
-                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                if (!(_response instanceof Error)) {
-                  _response = new Error(
-                    [
-                      `[dataloader-codegen :: getFilms] Caught an error, but errorHandler did not return an Error object.`,
-                      `Instead, got ${typeof _response}: ${util.inspect(
-                        _response
-                      )}`
-                    ].join(" ")
-                  );
-                }
-              }
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.after
-              ) {
-                _response = await options.resourceMiddleware.after(
-                  ["getFilms"],
-                  _response
-                );
-              }
-
-              return _response;
-            })(resourceArgs);
-
-            if (!(response instanceof Error)) {
-            }
-
-            if (!(response instanceof Error)) {
-              if (!Array.isArray(response)) {
-                response = new Error(
-                  [
-                    "[dataloader-codegen :: getFilms]",
-                    "Expected response to be an array!"
-                  ].join(" ")
-                );
-              }
-            }
-
-            if (!(response instanceof Error)) {
-              /**
-               * Check to see the resource contains the same number
-               * of items that we requested. If not, since there's
-               * no "reorderResultsByKey" specified for this resource,
-               * we don't know _which_ key's response is missing. Therefore
-               * it's unsafe to return the response array back.
-               */
-              if (response.length !== requests.length) {
-                /**
-                 * We must return errors for all keys in this group :(
-                 */
-                response = new BatchItemNotFoundError(
-                  [
-                    `[dataloader-codegen :: getFilms] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
-                  ].join(" ")
-                );
-
-                // Tell flow that BatchItemNotFoundError extends Error.
-                // It's an issue with flowgen package, but not an issue with Flow.
-                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                invariant(
-                  response instanceof Error,
-                  "expected BatchItemNotFoundError to be an Error"
-                );
-              }
-            }
-
-            /**
-             * If the resource returns an Error, we'll want to copy and
-             * return that error as the return value for every request in
-             * this group.
-             *
-             * This allow the error to be cached, and allows the rest of the
-             * requests made by this DataLoader to succeed.
-             *
-             * @see https://github.com/graphql/dataloader#caching-errors
-             */
-            if (response instanceof Error) {
-              response = requestIDs.map(requestId => {
-                /**
-                 * Since we're returning an error object and not the
-                 * expected return type from the resource, this element
-                 * would be unsortable, since it wouldn't have the
-                 * "reorderResultsByKey" attribute.
-                 *
-                 * Let's add it to the error object, as "reorderResultsByValue".
-                 *
-                 * (If we didn't specify that this resource needs
-                 * sorting, then this will be "null" and won't be used.)
-                 */
-                const reorderResultsByValue = null;
-
-                // Tell flow that "response" is actually an error object.
-                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                invariant(
-                  response instanceof Error,
-                  "expected response to be an error"
-                );
-
-                return new CaughtResourceError(
-                  `[dataloader-codegen :: getFilms] Caught error during call to resource. Error: ${response.stack}`,
-                  response,
-                  reorderResultsByValue
-                );
-              });
-            }
-
-            return response;
-          })
-        );
-
-        // Split the results back up into the order that they were requested
-        return unPartitionResults(requestGroups, groupedResults);
-      },
-      {
-        ...cacheKeyOptions
-      }
-    ),
-    getFilmsV2: new DataLoader<
-      {|
-        ...$Diff<
-          $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
-          {
-            film_ids: $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
-              "film_ids"
-            >
-          }
-        >,
-        ...{|
-          film_id: $ElementType<
-            $PropertyType<
-              $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
-              "film_ids"
+                ...{|
+                    planet_id: $ElementType<
+                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>, 'planet_ids'>,
+                        0,
+                    >,
+                |},
+            |},
+            $ElementType<
+                $Call<
+                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>]>,
+                    $PropertyType<ResourcesType, 'getPlanets'>,
+                >,
+                0,
             >,
-            0
-          >
-        |}
-      |},
-      $ElementType<
-        $PropertyType<
-          $Call<
-            ExtractPromisedReturnValue<
-              [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>]
+            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+            string,
+        >(
+            /**
+             * ===============================================================
+             * Generated DataLoader: getPlanets
+             * ===============================================================
+             *
+             * Resource Config:
+             *
+             * ```json
+             * {
+             *   "docsLink": "https://swapi.dev/documentation#planets",
+             *   "isBatchResource": true,
+             *   "batchKey": "planet_ids",
+             *   "newKey": "planet_id"
+             * }
+             * ```
+             */
+            async (keys) => {
+                invariant(
+                    typeof resources.getPlanets === 'function',
+                    [
+                        '[dataloader-codegen :: getPlanets] resources.getPlanets is not a function.',
+                        'Did you pass in an instance of getPlanets to "getLoaders"?',
+                    ].join(' '),
+                );
+
+                /**
+                 * Chunk up the "keys" array to create a set of "request groups".
+                 *
+                 * We're about to hit a batch resource. In addition to the batch
+                 * key, the resource may take other arguments too. When batching
+                 * up requests, we'll want to look out for where those other
+                 * arguments differ, and send multiple requests so we don't get
+                 * back the wrong info.
+                 *
+                 * In other words, we'll potentially want to send _multiple_
+                 * requests to the underlying resource batch method in this
+                 * dataloader body.
+                 *
+                 * ~~~ Why? ~~~
+                 *
+                 * Consider what happens when we get called with arguments where
+                 * the non-batch keys differ.
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
+                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
+                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
+                 * ```
+                 *
+                 * If we collected everything up and tried to send the one
+                 * request to the resource as a batch request, how do we know
+                 * what the value for "include_private_data" should be? We're
+                 * going to have to group these up up and send two requests to
+                 * the resource to make sure we're requesting the right stuff.
+                 *
+                 * e.g. We'd need to make the following set of underlying resource
+                 * calls:
+                 *
+                 * ```js
+                 * foo({ foo_ids: [ 2 ], include_private_data: true });
+                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+                 * ```
+                 *
+                 * ~~~ tl;dr ~~~
+                 *
+                 * When we have calls to .load with differing non batch key args,
+                 * we'll need to send multiple requests to the underlying
+                 * resource to make sure we get the right results back.
+                 *
+                 * Let's create the request groups, where each element in the
+                 * group refers to a position in "keys" (i.e. a call to .load)
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * partitionItems([
+                 *   { bar_id: 7, include_extra_info: true },
+                 *   { bar_id: 8, include_extra_info: false },
+                 *   { bar_id: 9, include_extra_info: true },
+                 * ], 'bar_id')
+                 * ```
+                 *
+                 * Returns:
+                 * `[ [ 0, 2 ], [ 1 ] ]`
+                 *
+                 * We'll refer to each element in the group as a "request ID".
+                 */
+                const requestGroups = partitionItems('planet_id', keys);
+
+                // Map the request groups to a list of Promises - one for each request
+                const groupedResults = await Promise.all(
+                    requestGroups.map(async (requestIDs) => {
+                        /**
+                         * Select a set of elements in "keys", where all non-batch
+                         * keys should be identical.
+                         *
+                         * We're going to smoosh all these together into one payload to
+                         * send to the resource as a batch request!
+                         */
+                        const requests = requestIDs.map((id) => keys[id]);
+
+                        // For now, we assume that the dataloader key should be the first argument to the resource
+                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
+                        const resourceArgs = [
+                            {
+                                ..._.omit(requests[0], 'planet_id'),
+                                ['planet_ids']: requests.map((k) => k['planet_id']),
+                            },
+                        ];
+
+                        let response = await (async (_resourceArgs) => {
+                            // Make a re-assignable variable so flow/eslint doesn't complain
+                            let __resourceArgs = _resourceArgs;
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
+                                __resourceArgs = await options.resourceMiddleware.before(
+                                    ['getPlanets'],
+                                    __resourceArgs,
+                                );
+                            }
+
+                            let _response;
+                            try {
+                                // Finally, call the resource!
+                                _response = await resources.getPlanets(...__resourceArgs);
+                            } catch (error) {
+                                const errorHandler =
+                                    options && typeof options.errorHandler === 'function'
+                                        ? options.errorHandler
+                                        : defaultErrorHandler;
+
+                                /**
+                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                                 *
+                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                                 */
+                                _response = await errorHandler(['getPlanets'], error);
+
+                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                                if (!(_response instanceof Error)) {
+                                    _response = new Error(
+                                        [
+                                            `[dataloader-codegen :: getPlanets] Caught an error, but errorHandler did not return an Error object.`,
+                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
+                                        ].join(' '),
+                                    );
+                                }
+                            }
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
+                                _response = await options.resourceMiddleware.after(['getPlanets'], _response);
+                            }
+
+                            return _response;
+                        })(resourceArgs);
+
+                        if (!(response instanceof Error)) {
+                        }
+
+                        if (!(response instanceof Error)) {
+                            if (!Array.isArray(response)) {
+                                response = new Error(
+                                    ['[dataloader-codegen :: getPlanets]', 'Expected response to be an array!'].join(
+                                        ' ',
+                                    ),
+                                );
+                            }
+                        }
+
+                        if (!(response instanceof Error)) {
+                            /**
+                             * Check to see the resource contains the same number
+                             * of items that we requested. If not, since there's
+                             * no "reorderResultsByKey" specified for this resource,
+                             * we don't know _which_ key's response is missing. Therefore
+                             * it's unsafe to return the response array back.
+                             */
+                            if (response.length !== requests.length) {
+                                /**
+                                 * We must return errors for all keys in this group :(
+                                 */
+                                response = new BatchItemNotFoundError(
+                                    [
+                                        `[dataloader-codegen :: getPlanets] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
+                                    ].join(' '),
+                                );
+
+                                // Tell flow that BatchItemNotFoundError extends Error.
+                                // It's an issue with flowgen package, but not an issue with Flow.
+                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
+                            }
+                        }
+
+                        /**
+                         * If the resource returns an Error, we'll want to copy and
+                         * return that error as the return value for every request in
+                         * this group.
+                         *
+                         * This allow the error to be cached, and allows the rest of the
+                         * requests made by this DataLoader to succeed.
+                         *
+                         * @see https://github.com/graphql/dataloader#caching-errors
+                         */
+                        if (response instanceof Error) {
+                            response = requestIDs.map((requestId) => {
+                                /**
+                                 * Since we're returning an error object and not the
+                                 * expected return type from the resource, this element
+                                 * would be unsortable, since it wouldn't have the
+                                 * "reorderResultsByKey" attribute.
+                                 *
+                                 * Let's add it to the error object, as "reorderResultsByValue".
+                                 *
+                                 * (If we didn't specify that this resource needs
+                                 * sorting, then this will be "null" and won't be used.)
+                                 */
+                                const reorderResultsByValue = null;
+
+                                // Tell flow that "response" is actually an error object.
+                                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                                invariant(response instanceof Error, 'expected response to be an error');
+
+                                return new CaughtResourceError(
+                                    `[dataloader-codegen :: getPlanets] Caught error during call to resource. Error: ${response.stack}`,
+                                    response,
+                                    reorderResultsByValue,
+                                );
+                            });
+                        }
+
+                        return response;
+                    }),
+                );
+
+                // Split the results back up into the order that they were requested
+                return unPartitionResults(requestGroups, groupedResults);
+            },
+            {
+                ...cacheKeyOptions,
+            },
+        ),
+        getPeople: new DataLoader<
+            {|
+                ...$Diff<
+                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
+                    {
+                        people_ids: $PropertyType<
+                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
+                            'people_ids',
+                        >,
+                    },
+                >,
+                ...{|
+                    person_id: $ElementType<
+                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>, 'people_ids'>,
+                        0,
+                    >,
+                |},
+            |},
+            $ElementType<
+                $Call<
+                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>]>,
+                    $PropertyType<ResourcesType, 'getPeople'>,
+                >,
+                0,
             >,
-            $PropertyType<ResourcesType, "getFilmsV2">
-          >,
-          "properties"
-        >,
-        0
-      >,
-      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-      string
-    >(
-      /**
-       * ===============================================================
-       * Generated DataLoader: getFilmsV2
-       * ===============================================================
-       *
-       * Resource Config:
-       *
-       * ```json
-       * {
-       *   "docsLink": "https://swapi.dev/documentation#films",
-       *   "isBatchResource": true,
-       *   "batchKey": "film_ids",
-       *   "newKey": "film_id",
-       *   "nestedPath": "properties"
-       * }
-       * ```
-       */
-      async keys => {
-        invariant(
-          typeof resources.getFilmsV2 === "function",
-          [
-            "[dataloader-codegen :: getFilmsV2] resources.getFilmsV2 is not a function.",
-            'Did you pass in an instance of getFilmsV2 to "getLoaders"?'
-          ].join(" ")
-        );
-
-        /**
-         * Chunk up the "keys" array to create a set of "request groups".
-         *
-         * We're about to hit a batch resource. In addition to the batch
-         * key, the resource may take other arguments too. When batching
-         * up requests, we'll want to look out for where those other
-         * arguments differ, and send multiple requests so we don't get
-         * back the wrong info.
-         *
-         * In other words, we'll potentially want to send _multiple_
-         * requests to the underlying resource batch method in this
-         * dataloader body.
-         *
-         * ~~~ Why? ~~~
-         *
-         * Consider what happens when we get called with arguments where
-         * the non-batch keys differ.
-         *
-         * Example:
-         *
-         * ```js
-         * loaders.foo.load({ foo_id: 2, include_private_data: true });
-         * loaders.foo.load({ foo_id: 3, include_private_data: false });
-         * loaders.foo.load({ foo_id: 4, include_private_data: false });
-         * ```
-         *
-         * If we collected everything up and tried to send the one
-         * request to the resource as a batch request, how do we know
-         * what the value for "include_private_data" should be? We're
-         * going to have to group these up up and send two requests to
-         * the resource to make sure we're requesting the right stuff.
-         *
-         * e.g. We'd need to make the following set of underlying resource
-         * calls:
-         *
-         * ```js
-         * foo({ foo_ids: [ 2 ], include_private_data: true });
-         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-         * ```
-         *
-         * ~~~ tl;dr ~~~
-         *
-         * When we have calls to .load with differing non batch key args,
-         * we'll need to send multiple requests to the underlying
-         * resource to make sure we get the right results back.
-         *
-         * Let's create the request groups, where each element in the
-         * group refers to a position in "keys" (i.e. a call to .load)
-         *
-         * Example:
-         *
-         * ```js
-         * partitionItems([
-         *   { bar_id: 7, include_extra_info: true },
-         *   { bar_id: 8, include_extra_info: false },
-         *   { bar_id: 9, include_extra_info: true },
-         * ], 'bar_id')
-         * ```
-         *
-         * Returns:
-         * `[ [ 0, 2 ], [ 1 ] ]`
-         *
-         * We'll refer to each element in the group as a "request ID".
-         */
-        const requestGroups = partitionItems("film_id", keys);
-
-        // Map the request groups to a list of Promises - one for each request
-        const groupedResults = await Promise.all(
-          requestGroups.map(async requestIDs => {
+            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+            string,
+        >(
             /**
-             * Select a set of elements in "keys", where all non-batch
-             * keys should be identical.
+             * ===============================================================
+             * Generated DataLoader: getPeople
+             * ===============================================================
              *
-             * We're going to smoosh all these together into one payload to
-             * send to the resource as a batch request!
+             * Resource Config:
+             *
+             * ```json
+             * {
+             *   "docsLink": "https://swapi.dev/documentation#people",
+             *   "isBatchResource": true,
+             *   "batchKey": "people_ids",
+             *   "newKey": "person_id"
+             * }
+             * ```
              */
-            const requests = requestIDs.map(id => keys[id]);
-
-            // For now, we assume that the dataloader key should be the first argument to the resource
-            // @see https://github.com/Yelp/dataloader-codegen/issues/56
-            const resourceArgs = [
-              {
-                ..._.omit(requests[0], "film_id"),
-                ["film_ids"]: requests.map(k => k["film_id"])
-              }
-            ];
-
-            let response = await (async _resourceArgs => {
-              // Make a re-assignable variable so flow/eslint doesn't complain
-              let __resourceArgs = _resourceArgs;
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.before
-              ) {
-                __resourceArgs = await options.resourceMiddleware.before(
-                  ["getFilmsV2"],
-                  __resourceArgs
-                );
-              }
-
-              let _response;
-              try {
-                // Finally, call the resource!
-                _response = await resources.getFilmsV2(...__resourceArgs);
-              } catch (error) {
-                const errorHandler =
-                  options && typeof options.errorHandler === "function"
-                    ? options.errorHandler
-                    : defaultErrorHandler;
-
-                /**
-                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                 *
-                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                 */
-                _response = await errorHandler(["getFilmsV2"], error);
-
-                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                if (!(_response instanceof Error)) {
-                  _response = new Error(
-                    [
-                      `[dataloader-codegen :: getFilmsV2] Caught an error, but errorHandler did not return an Error object.`,
-                      `Instead, got ${typeof _response}: ${util.inspect(
-                        _response
-                      )}`
-                    ].join(" ")
-                  );
-                }
-              }
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.after
-              ) {
-                _response = await options.resourceMiddleware.after(
-                  ["getFilmsV2"],
-                  _response
-                );
-              }
-
-              return _response;
-            })(resourceArgs);
-
-            if (!(response instanceof Error)) {
-              /**
-               * Un-nest the actual data from the resource return value.
-               *
-               * e.g.
-               * ```js
-               * {
-               *   foos: [
-               *     { id: 1, value: 'hello' },
-               *     { id: 2, value: 'world' },
-               *   ]
-               * }
-               * ```
-               *
-               * Becomes
-               *
-               * ```js
-               * [
-               *   { id: 1, value: 'hello' },
-               *   { id: 2, value: 'world' },
-               * ]
-               * ```
-               */
-              response = _.get(
-                response,
-                "properties",
-                new Error(
-                  [
-                    "[dataloader-codegen :: getFilmsV2]",
-                    "Tried to un-nest the response from the resource, but",
-                    ".get(response, 'properties')",
-                    "was empty!"
-                  ].join(" ")
-                )
-              );
-            }
-
-            if (!(response instanceof Error)) {
-              if (!Array.isArray(response)) {
-                response = new Error(
-                  [
-                    "[dataloader-codegen :: getFilmsV2]",
-                    "Expected response to be an array!"
-                  ].join(" ")
-                );
-              }
-            }
-
-            if (!(response instanceof Error)) {
-              /**
-               * Check to see the resource contains the same number
-               * of items that we requested. If not, since there's
-               * no "reorderResultsByKey" specified for this resource,
-               * we don't know _which_ key's response is missing. Therefore
-               * it's unsafe to return the response array back.
-               */
-              if (response.length !== requests.length) {
-                /**
-                 * We must return errors for all keys in this group :(
-                 */
-                response = new BatchItemNotFoundError(
-                  [
-                    `[dataloader-codegen :: getFilmsV2] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
-                  ].join(" ")
-                );
-
-                // Tell flow that BatchItemNotFoundError extends Error.
-                // It's an issue with flowgen package, but not an issue with Flow.
-                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+            async (keys) => {
                 invariant(
-                  response instanceof Error,
-                  "expected BatchItemNotFoundError to be an Error"
+                    typeof resources.getPeople === 'function',
+                    [
+                        '[dataloader-codegen :: getPeople] resources.getPeople is not a function.',
+                        'Did you pass in an instance of getPeople to "getLoaders"?',
+                    ].join(' '),
                 );
-              }
-            }
 
+                /**
+                 * Chunk up the "keys" array to create a set of "request groups".
+                 *
+                 * We're about to hit a batch resource. In addition to the batch
+                 * key, the resource may take other arguments too. When batching
+                 * up requests, we'll want to look out for where those other
+                 * arguments differ, and send multiple requests so we don't get
+                 * back the wrong info.
+                 *
+                 * In other words, we'll potentially want to send _multiple_
+                 * requests to the underlying resource batch method in this
+                 * dataloader body.
+                 *
+                 * ~~~ Why? ~~~
+                 *
+                 * Consider what happens when we get called with arguments where
+                 * the non-batch keys differ.
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
+                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
+                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
+                 * ```
+                 *
+                 * If we collected everything up and tried to send the one
+                 * request to the resource as a batch request, how do we know
+                 * what the value for "include_private_data" should be? We're
+                 * going to have to group these up up and send two requests to
+                 * the resource to make sure we're requesting the right stuff.
+                 *
+                 * e.g. We'd need to make the following set of underlying resource
+                 * calls:
+                 *
+                 * ```js
+                 * foo({ foo_ids: [ 2 ], include_private_data: true });
+                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+                 * ```
+                 *
+                 * ~~~ tl;dr ~~~
+                 *
+                 * When we have calls to .load with differing non batch key args,
+                 * we'll need to send multiple requests to the underlying
+                 * resource to make sure we get the right results back.
+                 *
+                 * Let's create the request groups, where each element in the
+                 * group refers to a position in "keys" (i.e. a call to .load)
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * partitionItems([
+                 *   { bar_id: 7, include_extra_info: true },
+                 *   { bar_id: 8, include_extra_info: false },
+                 *   { bar_id: 9, include_extra_info: true },
+                 * ], 'bar_id')
+                 * ```
+                 *
+                 * Returns:
+                 * `[ [ 0, 2 ], [ 1 ] ]`
+                 *
+                 * We'll refer to each element in the group as a "request ID".
+                 */
+                const requestGroups = partitionItems('person_id', keys);
+
+                // Map the request groups to a list of Promises - one for each request
+                const groupedResults = await Promise.all(
+                    requestGroups.map(async (requestIDs) => {
+                        /**
+                         * Select a set of elements in "keys", where all non-batch
+                         * keys should be identical.
+                         *
+                         * We're going to smoosh all these together into one payload to
+                         * send to the resource as a batch request!
+                         */
+                        const requests = requestIDs.map((id) => keys[id]);
+
+                        // For now, we assume that the dataloader key should be the first argument to the resource
+                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
+                        const resourceArgs = [
+                            {
+                                ..._.omit(requests[0], 'person_id'),
+                                ['people_ids']: requests.map((k) => k['person_id']),
+                            },
+                        ];
+
+                        let response = await (async (_resourceArgs) => {
+                            // Make a re-assignable variable so flow/eslint doesn't complain
+                            let __resourceArgs = _resourceArgs;
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
+                                __resourceArgs = await options.resourceMiddleware.before(['getPeople'], __resourceArgs);
+                            }
+
+                            let _response;
+                            try {
+                                // Finally, call the resource!
+                                _response = await resources.getPeople(...__resourceArgs);
+                            } catch (error) {
+                                const errorHandler =
+                                    options && typeof options.errorHandler === 'function'
+                                        ? options.errorHandler
+                                        : defaultErrorHandler;
+
+                                /**
+                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                                 *
+                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                                 */
+                                _response = await errorHandler(['getPeople'], error);
+
+                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                                if (!(_response instanceof Error)) {
+                                    _response = new Error(
+                                        [
+                                            `[dataloader-codegen :: getPeople] Caught an error, but errorHandler did not return an Error object.`,
+                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
+                                        ].join(' '),
+                                    );
+                                }
+                            }
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
+                                _response = await options.resourceMiddleware.after(['getPeople'], _response);
+                            }
+
+                            return _response;
+                        })(resourceArgs);
+
+                        if (!(response instanceof Error)) {
+                        }
+
+                        if (!(response instanceof Error)) {
+                            if (!Array.isArray(response)) {
+                                response = new Error(
+                                    ['[dataloader-codegen :: getPeople]', 'Expected response to be an array!'].join(
+                                        ' ',
+                                    ),
+                                );
+                            }
+                        }
+
+                        if (!(response instanceof Error)) {
+                            /**
+                             * Check to see the resource contains the same number
+                             * of items that we requested. If not, since there's
+                             * no "reorderResultsByKey" specified for this resource,
+                             * we don't know _which_ key's response is missing. Therefore
+                             * it's unsafe to return the response array back.
+                             */
+                            if (response.length !== requests.length) {
+                                /**
+                                 * We must return errors for all keys in this group :(
+                                 */
+                                response = new BatchItemNotFoundError(
+                                    [
+                                        `[dataloader-codegen :: getPeople] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
+                                    ].join(' '),
+                                );
+
+                                // Tell flow that BatchItemNotFoundError extends Error.
+                                // It's an issue with flowgen package, but not an issue with Flow.
+                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
+                            }
+                        }
+
+                        /**
+                         * If the resource returns an Error, we'll want to copy and
+                         * return that error as the return value for every request in
+                         * this group.
+                         *
+                         * This allow the error to be cached, and allows the rest of the
+                         * requests made by this DataLoader to succeed.
+                         *
+                         * @see https://github.com/graphql/dataloader#caching-errors
+                         */
+                        if (response instanceof Error) {
+                            response = requestIDs.map((requestId) => {
+                                /**
+                                 * Since we're returning an error object and not the
+                                 * expected return type from the resource, this element
+                                 * would be unsortable, since it wouldn't have the
+                                 * "reorderResultsByKey" attribute.
+                                 *
+                                 * Let's add it to the error object, as "reorderResultsByValue".
+                                 *
+                                 * (If we didn't specify that this resource needs
+                                 * sorting, then this will be "null" and won't be used.)
+                                 */
+                                const reorderResultsByValue = null;
+
+                                // Tell flow that "response" is actually an error object.
+                                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                                invariant(response instanceof Error, 'expected response to be an error');
+
+                                return new CaughtResourceError(
+                                    `[dataloader-codegen :: getPeople] Caught error during call to resource. Error: ${response.stack}`,
+                                    response,
+                                    reorderResultsByValue,
+                                );
+                            });
+                        }
+
+                        return response;
+                    }),
+                );
+
+                // Split the results back up into the order that they were requested
+                return unPartitionResults(requestGroups, groupedResults);
+            },
+            {
+                ...cacheKeyOptions,
+            },
+        ),
+        getVehicles: new DataLoader<
+            {|
+                ...$Diff<
+                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
+                    {
+                        vehicle_ids: $PropertyType<
+                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
+                            'vehicle_ids',
+                        >,
+                    },
+                >,
+                ...{|
+                    vehicle_id: $ElementType<
+                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>, 'vehicle_ids'>,
+                        0,
+                    >,
+                |},
+            |},
+            $ElementType<
+                $Call<
+                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>]>,
+                    $PropertyType<ResourcesType, 'getVehicles'>,
+                >,
+                0,
+            >,
+            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+            string,
+        >(
             /**
-             * If the resource returns an Error, we'll want to copy and
-             * return that error as the return value for every request in
-             * this group.
+             * ===============================================================
+             * Generated DataLoader: getVehicles
+             * ===============================================================
              *
-             * This allow the error to be cached, and allows the rest of the
-             * requests made by this DataLoader to succeed.
+             * Resource Config:
              *
-             * @see https://github.com/graphql/dataloader#caching-errors
+             * ```json
+             * {
+             *   "docsLink": "https://swapi.dev/documentation#vehicles",
+             *   "isBatchResource": true,
+             *   "batchKey": "vehicle_ids",
+             *   "newKey": "vehicle_id"
+             * }
+             * ```
              */
-            if (response instanceof Error) {
-              response = requestIDs.map(requestId => {
-                /**
-                 * Since we're returning an error object and not the
-                 * expected return type from the resource, this element
-                 * would be unsortable, since it wouldn't have the
-                 * "reorderResultsByKey" attribute.
-                 *
-                 * Let's add it to the error object, as "reorderResultsByValue".
-                 *
-                 * (If we didn't specify that this resource needs
-                 * sorting, then this will be "null" and won't be used.)
-                 */
-                const reorderResultsByValue = null;
-
-                // Tell flow that "response" is actually an error object.
-                // (This is so we can pass it as 'cause' to CaughtResourceError)
+            async (keys) => {
                 invariant(
-                  response instanceof Error,
-                  "expected response to be an error"
+                    typeof resources.getVehicles === 'function',
+                    [
+                        '[dataloader-codegen :: getVehicles] resources.getVehicles is not a function.',
+                        'Did you pass in an instance of getVehicles to "getLoaders"?',
+                    ].join(' '),
                 );
-
-                return new CaughtResourceError(
-                  `[dataloader-codegen :: getFilmsV2] Caught error during call to resource. Error: ${response.stack}`,
-                  response,
-                  reorderResultsByValue
-                );
-              });
-            }
-
-            return response;
-          })
-        );
-
-        // Split the results back up into the order that they were requested
-        return unPartitionResults(requestGroups, groupedResults);
-      },
-      {
-        ...cacheKeyOptions
-      }
-    ),
-    getRoot: new DataLoader<
-      $Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>,
-      $Call<
-        ExtractPromisedReturnValue<
-          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>]
-        >,
-        $PropertyType<ResourcesType, "getRoot">
-      >,
-      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-      string
-    >(
-      /**
-       * ===============================================================
-       * Generated DataLoader: getRoot
-       * ===============================================================
-       *
-       * Resource Config:
-       *
-       * ```json
-       * {
-       *   "docsLink": "https://swapi.dev/documentation#root",
-       *   "isBatchResource": false
-       * }
-       * ```
-       */
-      async keys => {
-        const responses = await Promise.all(
-          keys.map(async key => {
-            invariant(
-              typeof resources.getRoot === "function",
-              [
-                "[dataloader-codegen :: getRoot] resources.getRoot is not a function.",
-                'Did you pass in an instance of getRoot to "getLoaders"?'
-              ].join(" ")
-            );
-
-            // For now, we assume that the dataloader key should be the first argument to the resource
-            // @see https://github.com/Yelp/dataloader-codegen/issues/56
-            const resourceArgs = [key];
-
-            return await (async _resourceArgs => {
-              // Make a re-assignable variable so flow/eslint doesn't complain
-              let __resourceArgs = _resourceArgs;
-
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.before
-              ) {
-                __resourceArgs = await options.resourceMiddleware.before(
-                  ["getRoot"],
-                  __resourceArgs
-                );
-              }
-
-              let _response;
-              try {
-                // Finally, call the resource!
-                _response = await resources.getRoot(...__resourceArgs);
-              } catch (error) {
-                const errorHandler =
-                  options && typeof options.errorHandler === "function"
-                    ? options.errorHandler
-                    : defaultErrorHandler;
 
                 /**
-                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                 * Chunk up the "keys" array to create a set of "request groups".
                  *
-                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                 * We're about to hit a batch resource. In addition to the batch
+                 * key, the resource may take other arguments too. When batching
+                 * up requests, we'll want to look out for where those other
+                 * arguments differ, and send multiple requests so we don't get
+                 * back the wrong info.
+                 *
+                 * In other words, we'll potentially want to send _multiple_
+                 * requests to the underlying resource batch method in this
+                 * dataloader body.
+                 *
+                 * ~~~ Why? ~~~
+                 *
+                 * Consider what happens when we get called with arguments where
+                 * the non-batch keys differ.
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
+                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
+                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
+                 * ```
+                 *
+                 * If we collected everything up and tried to send the one
+                 * request to the resource as a batch request, how do we know
+                 * what the value for "include_private_data" should be? We're
+                 * going to have to group these up up and send two requests to
+                 * the resource to make sure we're requesting the right stuff.
+                 *
+                 * e.g. We'd need to make the following set of underlying resource
+                 * calls:
+                 *
+                 * ```js
+                 * foo({ foo_ids: [ 2 ], include_private_data: true });
+                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+                 * ```
+                 *
+                 * ~~~ tl;dr ~~~
+                 *
+                 * When we have calls to .load with differing non batch key args,
+                 * we'll need to send multiple requests to the underlying
+                 * resource to make sure we get the right results back.
+                 *
+                 * Let's create the request groups, where each element in the
+                 * group refers to a position in "keys" (i.e. a call to .load)
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * partitionItems([
+                 *   { bar_id: 7, include_extra_info: true },
+                 *   { bar_id: 8, include_extra_info: false },
+                 *   { bar_id: 9, include_extra_info: true },
+                 * ], 'bar_id')
+                 * ```
+                 *
+                 * Returns:
+                 * `[ [ 0, 2 ], [ 1 ] ]`
+                 *
+                 * We'll refer to each element in the group as a "request ID".
                  */
-                _response = await errorHandler(["getRoot"], error);
+                const requestGroups = partitionItems('vehicle_id', keys);
 
-                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                if (!(_response instanceof Error)) {
-                  _response = new Error(
-                    [
-                      `[dataloader-codegen :: getRoot] Caught an error, but errorHandler did not return an Error object.`,
-                      `Instead, got ${typeof _response}: ${util.inspect(
-                        _response
-                      )}`
-                    ].join(" ")
-                  );
-                }
-              }
+                // Map the request groups to a list of Promises - one for each request
+                const groupedResults = await Promise.all(
+                    requestGroups.map(async (requestIDs) => {
+                        /**
+                         * Select a set of elements in "keys", where all non-batch
+                         * keys should be identical.
+                         *
+                         * We're going to smoosh all these together into one payload to
+                         * send to the resource as a batch request!
+                         */
+                        const requests = requestIDs.map((id) => keys[id]);
 
-              if (
-                options &&
-                options.resourceMiddleware &&
-                options.resourceMiddleware.after
-              ) {
-                _response = await options.resourceMiddleware.after(
-                  ["getRoot"],
-                  _response
+                        // For now, we assume that the dataloader key should be the first argument to the resource
+                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
+                        const resourceArgs = [
+                            {
+                                ..._.omit(requests[0], 'vehicle_id'),
+                                ['vehicle_ids']: requests.map((k) => k['vehicle_id']),
+                            },
+                        ];
+
+                        let response = await (async (_resourceArgs) => {
+                            // Make a re-assignable variable so flow/eslint doesn't complain
+                            let __resourceArgs = _resourceArgs;
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
+                                __resourceArgs = await options.resourceMiddleware.before(
+                                    ['getVehicles'],
+                                    __resourceArgs,
+                                );
+                            }
+
+                            let _response;
+                            try {
+                                // Finally, call the resource!
+                                _response = await resources.getVehicles(...__resourceArgs);
+                            } catch (error) {
+                                const errorHandler =
+                                    options && typeof options.errorHandler === 'function'
+                                        ? options.errorHandler
+                                        : defaultErrorHandler;
+
+                                /**
+                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                                 *
+                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                                 */
+                                _response = await errorHandler(['getVehicles'], error);
+
+                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                                if (!(_response instanceof Error)) {
+                                    _response = new Error(
+                                        [
+                                            `[dataloader-codegen :: getVehicles] Caught an error, but errorHandler did not return an Error object.`,
+                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
+                                        ].join(' '),
+                                    );
+                                }
+                            }
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
+                                _response = await options.resourceMiddleware.after(['getVehicles'], _response);
+                            }
+
+                            return _response;
+                        })(resourceArgs);
+
+                        if (!(response instanceof Error)) {
+                        }
+
+                        if (!(response instanceof Error)) {
+                            if (!Array.isArray(response)) {
+                                response = new Error(
+                                    ['[dataloader-codegen :: getVehicles]', 'Expected response to be an array!'].join(
+                                        ' ',
+                                    ),
+                                );
+                            }
+                        }
+
+                        if (!(response instanceof Error)) {
+                            /**
+                             * Check to see the resource contains the same number
+                             * of items that we requested. If not, since there's
+                             * no "reorderResultsByKey" specified for this resource,
+                             * we don't know _which_ key's response is missing. Therefore
+                             * it's unsafe to return the response array back.
+                             */
+                            if (response.length !== requests.length) {
+                                /**
+                                 * We must return errors for all keys in this group :(
+                                 */
+                                response = new BatchItemNotFoundError(
+                                    [
+                                        `[dataloader-codegen :: getVehicles] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
+                                    ].join(' '),
+                                );
+
+                                // Tell flow that BatchItemNotFoundError extends Error.
+                                // It's an issue with flowgen package, but not an issue with Flow.
+                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
+                            }
+                        }
+
+                        /**
+                         * If the resource returns an Error, we'll want to copy and
+                         * return that error as the return value for every request in
+                         * this group.
+                         *
+                         * This allow the error to be cached, and allows the rest of the
+                         * requests made by this DataLoader to succeed.
+                         *
+                         * @see https://github.com/graphql/dataloader#caching-errors
+                         */
+                        if (response instanceof Error) {
+                            response = requestIDs.map((requestId) => {
+                                /**
+                                 * Since we're returning an error object and not the
+                                 * expected return type from the resource, this element
+                                 * would be unsortable, since it wouldn't have the
+                                 * "reorderResultsByKey" attribute.
+                                 *
+                                 * Let's add it to the error object, as "reorderResultsByValue".
+                                 *
+                                 * (If we didn't specify that this resource needs
+                                 * sorting, then this will be "null" and won't be used.)
+                                 */
+                                const reorderResultsByValue = null;
+
+                                // Tell flow that "response" is actually an error object.
+                                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                                invariant(response instanceof Error, 'expected response to be an error');
+
+                                return new CaughtResourceError(
+                                    `[dataloader-codegen :: getVehicles] Caught error during call to resource. Error: ${response.stack}`,
+                                    response,
+                                    reorderResultsByValue,
+                                );
+                            });
+                        }
+
+                        return response;
+                    }),
                 );
-              }
 
-              return _response;
-            })(resourceArgs);
-          })
-        );
+                // Split the results back up into the order that they were requested
+                return unPartitionResults(requestGroups, groupedResults);
+            },
+            {
+                ...cacheKeyOptions,
+            },
+        ),
+        getFilms: new DataLoader<
+            {|
+                ...$Diff<
+                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
+                    {
+                        film_ids: $PropertyType<
+                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
+                            'film_ids',
+                        >,
+                    },
+                >,
+                ...{|
+                    film_id: $Call<
+                        ExtractArg,
+                        [
+                            $PropertyType<
+                                $PropertyType<
+                                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
+                                    'film_ids',
+                                >,
+                                'has',
+                            >,
+                        ],
+                    >,
+                |},
+            |},
+            $ElementType<
+                $Call<
+                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>]>,
+                    $PropertyType<ResourcesType, 'getFilms'>,
+                >,
+                0,
+            >,
+            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+            string,
+        >(
+            /**
+             * ===============================================================
+             * Generated DataLoader: getFilms
+             * ===============================================================
+             *
+             * Resource Config:
+             *
+             * ```json
+             * {
+             *   "docsLink": "https://swapi.dev/documentation#films",
+             *   "isBatchResource": true,
+             *   "batchKey": "film_ids",
+             *   "newKey": "film_id",
+             *   "isBatchKeyASet": true
+             * }
+             * ```
+             */
+            async (keys) => {
+                invariant(
+                    typeof resources.getFilms === 'function',
+                    [
+                        '[dataloader-codegen :: getFilms] resources.getFilms is not a function.',
+                        'Did you pass in an instance of getFilms to "getLoaders"?',
+                    ].join(' '),
+                );
 
-        return responses;
-      },
-      {
-        ...cacheKeyOptions
-      }
-    )
-  });
+                /**
+                 * Chunk up the "keys" array to create a set of "request groups".
+                 *
+                 * We're about to hit a batch resource. In addition to the batch
+                 * key, the resource may take other arguments too. When batching
+                 * up requests, we'll want to look out for where those other
+                 * arguments differ, and send multiple requests so we don't get
+                 * back the wrong info.
+                 *
+                 * In other words, we'll potentially want to send _multiple_
+                 * requests to the underlying resource batch method in this
+                 * dataloader body.
+                 *
+                 * ~~~ Why? ~~~
+                 *
+                 * Consider what happens when we get called with arguments where
+                 * the non-batch keys differ.
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
+                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
+                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
+                 * ```
+                 *
+                 * If we collected everything up and tried to send the one
+                 * request to the resource as a batch request, how do we know
+                 * what the value for "include_private_data" should be? We're
+                 * going to have to group these up up and send two requests to
+                 * the resource to make sure we're requesting the right stuff.
+                 *
+                 * e.g. We'd need to make the following set of underlying resource
+                 * calls:
+                 *
+                 * ```js
+                 * foo({ foo_ids: [ 2 ], include_private_data: true });
+                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+                 * ```
+                 *
+                 * ~~~ tl;dr ~~~
+                 *
+                 * When we have calls to .load with differing non batch key args,
+                 * we'll need to send multiple requests to the underlying
+                 * resource to make sure we get the right results back.
+                 *
+                 * Let's create the request groups, where each element in the
+                 * group refers to a position in "keys" (i.e. a call to .load)
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * partitionItems([
+                 *   { bar_id: 7, include_extra_info: true },
+                 *   { bar_id: 8, include_extra_info: false },
+                 *   { bar_id: 9, include_extra_info: true },
+                 * ], 'bar_id')
+                 * ```
+                 *
+                 * Returns:
+                 * `[ [ 0, 2 ], [ 1 ] ]`
+                 *
+                 * We'll refer to each element in the group as a "request ID".
+                 */
+                const requestGroups = partitionItems('film_id', keys);
+
+                // Map the request groups to a list of Promises - one for each request
+                const groupedResults = await Promise.all(
+                    requestGroups.map(async (requestIDs) => {
+                        /**
+                         * Select a set of elements in "keys", where all non-batch
+                         * keys should be identical.
+                         *
+                         * We're going to smoosh all these together into one payload to
+                         * send to the resource as a batch request!
+                         */
+                        const requests = requestIDs.map((id) => keys[id]);
+
+                        // For now, we assume that the dataloader key should be the first argument to the resource
+                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
+                        const resourceArgs = [
+                            {
+                                ..._.omit(requests[0], 'film_id'),
+                                ['film_ids']: requests.map((k) => k['film_id']),
+                            },
+                        ];
+
+                        let response = await (async (_resourceArgs) => {
+                            // Make a re-assignable variable so flow/eslint doesn't complain
+                            let __resourceArgs = _resourceArgs;
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
+                                __resourceArgs = await options.resourceMiddleware.before(['getFilms'], __resourceArgs);
+                            }
+
+                            let _response;
+                            try {
+                                // Finally, call the resource!
+                                _response = await resources.getFilms(...__resourceArgs);
+                            } catch (error) {
+                                const errorHandler =
+                                    options && typeof options.errorHandler === 'function'
+                                        ? options.errorHandler
+                                        : defaultErrorHandler;
+
+                                /**
+                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                                 *
+                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                                 */
+                                _response = await errorHandler(['getFilms'], error);
+
+                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                                if (!(_response instanceof Error)) {
+                                    _response = new Error(
+                                        [
+                                            `[dataloader-codegen :: getFilms] Caught an error, but errorHandler did not return an Error object.`,
+                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
+                                        ].join(' '),
+                                    );
+                                }
+                            }
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
+                                _response = await options.resourceMiddleware.after(['getFilms'], _response);
+                            }
+
+                            return _response;
+                        })(resourceArgs);
+
+                        if (!(response instanceof Error)) {
+                        }
+
+                        if (!(response instanceof Error)) {
+                            if (!Array.isArray(response)) {
+                                response = new Error(
+                                    ['[dataloader-codegen :: getFilms]', 'Expected response to be an array!'].join(' '),
+                                );
+                            }
+                        }
+
+                        if (!(response instanceof Error)) {
+                            /**
+                             * Check to see the resource contains the same number
+                             * of items that we requested. If not, since there's
+                             * no "reorderResultsByKey" specified for this resource,
+                             * we don't know _which_ key's response is missing. Therefore
+                             * it's unsafe to return the response array back.
+                             */
+                            if (response.length !== requests.length) {
+                                /**
+                                 * We must return errors for all keys in this group :(
+                                 */
+                                response = new BatchItemNotFoundError(
+                                    [
+                                        `[dataloader-codegen :: getFilms] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
+                                    ].join(' '),
+                                );
+
+                                // Tell flow that BatchItemNotFoundError extends Error.
+                                // It's an issue with flowgen package, but not an issue with Flow.
+                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
+                            }
+                        }
+
+                        /**
+                         * If the resource returns an Error, we'll want to copy and
+                         * return that error as the return value for every request in
+                         * this group.
+                         *
+                         * This allow the error to be cached, and allows the rest of the
+                         * requests made by this DataLoader to succeed.
+                         *
+                         * @see https://github.com/graphql/dataloader#caching-errors
+                         */
+                        if (response instanceof Error) {
+                            response = requestIDs.map((requestId) => {
+                                /**
+                                 * Since we're returning an error object and not the
+                                 * expected return type from the resource, this element
+                                 * would be unsortable, since it wouldn't have the
+                                 * "reorderResultsByKey" attribute.
+                                 *
+                                 * Let's add it to the error object, as "reorderResultsByValue".
+                                 *
+                                 * (If we didn't specify that this resource needs
+                                 * sorting, then this will be "null" and won't be used.)
+                                 */
+                                const reorderResultsByValue = null;
+
+                                // Tell flow that "response" is actually an error object.
+                                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                                invariant(response instanceof Error, 'expected response to be an error');
+
+                                return new CaughtResourceError(
+                                    `[dataloader-codegen :: getFilms] Caught error during call to resource. Error: ${response.stack}`,
+                                    response,
+                                    reorderResultsByValue,
+                                );
+                            });
+                        }
+
+                        return response;
+                    }),
+                );
+
+                // Split the results back up into the order that they were requested
+                return unPartitionResults(requestGroups, groupedResults);
+            },
+            {
+                ...cacheKeyOptions,
+            },
+        ),
+        getFilmsV2: new DataLoader<
+            {|
+                ...$Diff<
+                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>,
+                    {
+                        film_ids: $PropertyType<
+                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>,
+                            'film_ids',
+                        >,
+                    },
+                >,
+                ...{|
+                    film_id: $ElementType<
+                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>, 'film_ids'>,
+                        0,
+                    >,
+                |},
+            |},
+            $ElementType<
+                $PropertyType<
+                    $Call<
+                        ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilmsV2'>]>]>,
+                        $PropertyType<ResourcesType, 'getFilmsV2'>,
+                    >,
+                    'properties',
+                >,
+                0,
+            >,
+            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+            string,
+        >(
+            /**
+             * ===============================================================
+             * Generated DataLoader: getFilmsV2
+             * ===============================================================
+             *
+             * Resource Config:
+             *
+             * ```json
+             * {
+             *   "docsLink": "https://swapi.dev/documentation#films",
+             *   "isBatchResource": true,
+             *   "batchKey": "film_ids",
+             *   "newKey": "film_id",
+             *   "nestedPath": "properties"
+             * }
+             * ```
+             */
+            async (keys) => {
+                invariant(
+                    typeof resources.getFilmsV2 === 'function',
+                    [
+                        '[dataloader-codegen :: getFilmsV2] resources.getFilmsV2 is not a function.',
+                        'Did you pass in an instance of getFilmsV2 to "getLoaders"?',
+                    ].join(' '),
+                );
+
+                /**
+                 * Chunk up the "keys" array to create a set of "request groups".
+                 *
+                 * We're about to hit a batch resource. In addition to the batch
+                 * key, the resource may take other arguments too. When batching
+                 * up requests, we'll want to look out for where those other
+                 * arguments differ, and send multiple requests so we don't get
+                 * back the wrong info.
+                 *
+                 * In other words, we'll potentially want to send _multiple_
+                 * requests to the underlying resource batch method in this
+                 * dataloader body.
+                 *
+                 * ~~~ Why? ~~~
+                 *
+                 * Consider what happens when we get called with arguments where
+                 * the non-batch keys differ.
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
+                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
+                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
+                 * ```
+                 *
+                 * If we collected everything up and tried to send the one
+                 * request to the resource as a batch request, how do we know
+                 * what the value for "include_private_data" should be? We're
+                 * going to have to group these up up and send two requests to
+                 * the resource to make sure we're requesting the right stuff.
+                 *
+                 * e.g. We'd need to make the following set of underlying resource
+                 * calls:
+                 *
+                 * ```js
+                 * foo({ foo_ids: [ 2 ], include_private_data: true });
+                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+                 * ```
+                 *
+                 * ~~~ tl;dr ~~~
+                 *
+                 * When we have calls to .load with differing non batch key args,
+                 * we'll need to send multiple requests to the underlying
+                 * resource to make sure we get the right results back.
+                 *
+                 * Let's create the request groups, where each element in the
+                 * group refers to a position in "keys" (i.e. a call to .load)
+                 *
+                 * Example:
+                 *
+                 * ```js
+                 * partitionItems([
+                 *   { bar_id: 7, include_extra_info: true },
+                 *   { bar_id: 8, include_extra_info: false },
+                 *   { bar_id: 9, include_extra_info: true },
+                 * ], 'bar_id')
+                 * ```
+                 *
+                 * Returns:
+                 * `[ [ 0, 2 ], [ 1 ] ]`
+                 *
+                 * We'll refer to each element in the group as a "request ID".
+                 */
+                const requestGroups = partitionItems('film_id', keys);
+
+                // Map the request groups to a list of Promises - one for each request
+                const groupedResults = await Promise.all(
+                    requestGroups.map(async (requestIDs) => {
+                        /**
+                         * Select a set of elements in "keys", where all non-batch
+                         * keys should be identical.
+                         *
+                         * We're going to smoosh all these together into one payload to
+                         * send to the resource as a batch request!
+                         */
+                        const requests = requestIDs.map((id) => keys[id]);
+
+                        // For now, we assume that the dataloader key should be the first argument to the resource
+                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
+                        const resourceArgs = [
+                            {
+                                ..._.omit(requests[0], 'film_id'),
+                                ['film_ids']: requests.map((k) => k['film_id']),
+                            },
+                        ];
+
+                        let response = await (async (_resourceArgs) => {
+                            // Make a re-assignable variable so flow/eslint doesn't complain
+                            let __resourceArgs = _resourceArgs;
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
+                                __resourceArgs = await options.resourceMiddleware.before(
+                                    ['getFilmsV2'],
+                                    __resourceArgs,
+                                );
+                            }
+
+                            let _response;
+                            try {
+                                // Finally, call the resource!
+                                _response = await resources.getFilmsV2(...__resourceArgs);
+                            } catch (error) {
+                                const errorHandler =
+                                    options && typeof options.errorHandler === 'function'
+                                        ? options.errorHandler
+                                        : defaultErrorHandler;
+
+                                /**
+                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                                 *
+                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                                 */
+                                _response = await errorHandler(['getFilmsV2'], error);
+
+                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                                if (!(_response instanceof Error)) {
+                                    _response = new Error(
+                                        [
+                                            `[dataloader-codegen :: getFilmsV2] Caught an error, but errorHandler did not return an Error object.`,
+                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
+                                        ].join(' '),
+                                    );
+                                }
+                            }
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
+                                _response = await options.resourceMiddleware.after(['getFilmsV2'], _response);
+                            }
+
+                            return _response;
+                        })(resourceArgs);
+
+                        if (!(response instanceof Error)) {
+                            /**
+                             * Un-nest the actual data from the resource return value.
+                             *
+                             * e.g.
+                             * ```js
+                             * {
+                             *   foos: [
+                             *     { id: 1, value: 'hello' },
+                             *     { id: 2, value: 'world' },
+                             *   ]
+                             * }
+                             * ```
+                             *
+                             * Becomes
+                             *
+                             * ```js
+                             * [
+                             *   { id: 1, value: 'hello' },
+                             *   { id: 2, value: 'world' },
+                             * ]
+                             * ```
+                             */
+                            response = _.get(
+                                response,
+                                'properties',
+                                new Error(
+                                    [
+                                        '[dataloader-codegen :: getFilmsV2]',
+                                        'Tried to un-nest the response from the resource, but',
+                                        ".get(response, 'properties')",
+                                        'was empty!',
+                                    ].join(' '),
+                                ),
+                            );
+                        }
+
+                        if (!(response instanceof Error)) {
+                            if (!Array.isArray(response)) {
+                                response = new Error(
+                                    ['[dataloader-codegen :: getFilmsV2]', 'Expected response to be an array!'].join(
+                                        ' ',
+                                    ),
+                                );
+                            }
+                        }
+
+                        if (!(response instanceof Error)) {
+                            /**
+                             * Check to see the resource contains the same number
+                             * of items that we requested. If not, since there's
+                             * no "reorderResultsByKey" specified for this resource,
+                             * we don't know _which_ key's response is missing. Therefore
+                             * it's unsafe to return the response array back.
+                             */
+                            if (response.length !== requests.length) {
+                                /**
+                                 * We must return errors for all keys in this group :(
+                                 */
+                                response = new BatchItemNotFoundError(
+                                    [
+                                        `[dataloader-codegen :: getFilmsV2] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
+                                    ].join(' '),
+                                );
+
+                                // Tell flow that BatchItemNotFoundError extends Error.
+                                // It's an issue with flowgen package, but not an issue with Flow.
+                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
+                            }
+                        }
+
+                        /**
+                         * If the resource returns an Error, we'll want to copy and
+                         * return that error as the return value for every request in
+                         * this group.
+                         *
+                         * This allow the error to be cached, and allows the rest of the
+                         * requests made by this DataLoader to succeed.
+                         *
+                         * @see https://github.com/graphql/dataloader#caching-errors
+                         */
+                        if (response instanceof Error) {
+                            response = requestIDs.map((requestId) => {
+                                /**
+                                 * Since we're returning an error object and not the
+                                 * expected return type from the resource, this element
+                                 * would be unsortable, since it wouldn't have the
+                                 * "reorderResultsByKey" attribute.
+                                 *
+                                 * Let's add it to the error object, as "reorderResultsByValue".
+                                 *
+                                 * (If we didn't specify that this resource needs
+                                 * sorting, then this will be "null" and won't be used.)
+                                 */
+                                const reorderResultsByValue = null;
+
+                                // Tell flow that "response" is actually an error object.
+                                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                                invariant(response instanceof Error, 'expected response to be an error');
+
+                                return new CaughtResourceError(
+                                    `[dataloader-codegen :: getFilmsV2] Caught error during call to resource. Error: ${response.stack}`,
+                                    response,
+                                    reorderResultsByValue,
+                                );
+                            });
+                        }
+
+                        return response;
+                    }),
+                );
+
+                // Split the results back up into the order that they were requested
+                return unPartitionResults(requestGroups, groupedResults);
+            },
+            {
+                ...cacheKeyOptions,
+            },
+        ),
+        getRoot: new DataLoader<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>,
+            $Call<
+                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>]>,
+                $PropertyType<ResourcesType, 'getRoot'>,
+            >,
+            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+            string,
+        >(
+            /**
+             * ===============================================================
+             * Generated DataLoader: getRoot
+             * ===============================================================
+             *
+             * Resource Config:
+             *
+             * ```json
+             * {
+             *   "docsLink": "https://swapi.dev/documentation#root",
+             *   "isBatchResource": false
+             * }
+             * ```
+             */
+            async (keys) => {
+                const responses = await Promise.all(
+                    keys.map(async (key) => {
+                        invariant(
+                            typeof resources.getRoot === 'function',
+                            [
+                                '[dataloader-codegen :: getRoot] resources.getRoot is not a function.',
+                                'Did you pass in an instance of getRoot to "getLoaders"?',
+                            ].join(' '),
+                        );
+
+                        // For now, we assume that the dataloader key should be the first argument to the resource
+                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
+                        const resourceArgs = [key];
+
+                        return await (async (_resourceArgs) => {
+                            // Make a re-assignable variable so flow/eslint doesn't complain
+                            let __resourceArgs = _resourceArgs;
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
+                                __resourceArgs = await options.resourceMiddleware.before(['getRoot'], __resourceArgs);
+                            }
+
+                            let _response;
+                            try {
+                                // Finally, call the resource!
+                                _response = await resources.getRoot(...__resourceArgs);
+                            } catch (error) {
+                                const errorHandler =
+                                    options && typeof options.errorHandler === 'function'
+                                        ? options.errorHandler
+                                        : defaultErrorHandler;
+
+                                /**
+                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                                 *
+                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                                 */
+                                _response = await errorHandler(['getRoot'], error);
+
+                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                                if (!(_response instanceof Error)) {
+                                    _response = new Error(
+                                        [
+                                            `[dataloader-codegen :: getRoot] Caught an error, but errorHandler did not return an Error object.`,
+                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
+                                        ].join(' '),
+                                    );
+                                }
+                            }
+
+                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
+                                _response = await options.resourceMiddleware.after(['getRoot'], _response);
+                            }
+
+                            return _response;
+                        })(resourceArgs);
+                    }),
+                );
+
+                return responses;
+            },
+            {
+                ...cacheKeyOptions,
+            },
+        ),
+    });
 }

--- a/examples/swapi/swapi-loaders.js
+++ b/examples/swapi/swapi-loaders.js
@@ -4,27 +4,27 @@
  * !!! THIS FILE IS AUTO-GENERATED. CHANGES MAY BE OVERWRITTEN !!!
  */
 
-import util from 'util';
-import _ from 'lodash';
-import invariant from 'assert';
-import DataLoader from 'dataloader';
+import util from "util";
+import _ from "lodash";
+import invariant from "assert";
+import DataLoader from "dataloader";
 import {
-    BatchItemNotFoundError,
-    cacheKeyOptions,
-    CaughtResourceError,
-    defaultErrorHandler,
-    partitionItems,
-    resultsDictToList,
-    sortByKeys,
-    unPartitionResults,
-} from 'dataloader-codegen/lib/runtimeHelpers';
+  BatchItemNotFoundError,
+  cacheKeyOptions,
+  CaughtResourceError,
+  defaultErrorHandler,
+  partitionItems,
+  resultsDictToList,
+  sortByKeys,
+  unPartitionResults
+} from "dataloader-codegen/lib/runtimeHelpers";
 
 /**
  * ===============================
  * BEGIN: printResourceTypeImports()
  * ===============================
  */
-import type { SWAPIClientlibTypes } from './swapi';
+import type { SWAPIClientlibTypes } from "./swapi";
 
 /**
  * ===============================
@@ -37,15 +37,18 @@ type ExtractArg = <Arg, Ret>([(Arg) => Ret]) => Arg;
 type ExtractPromisedReturnValue<A> = <R>((...A) => Promise<R>) => R;
 
 export type DataLoaderCodegenOptions = {|
-    errorHandler?: (
-        resourcePath: $ReadOnlyArray<string>,
-        // $FlowFixMe: We don't know what type the resource might throw, so we have to type error to "any" :(
-        error: any,
-    ) => Promise<Error>,
-    resourceMiddleware?: {|
-        before?: <T>(resourcePath: $ReadOnlyArray<string>, resourceArgs: T) => Promise<T>,
-        after?: <T>(resourcePath: $ReadOnlyArray<string>, response: T) => Promise<T>,
-    |},
+  errorHandler?: (
+    resourcePath: $ReadOnlyArray<string>,
+    // $FlowFixMe: We don't know what type the resource might throw, so we have to type error to "any" :(
+    error: any
+  ) => Promise<Error>,
+  resourceMiddleware?: {|
+    before?: <T>(
+      resourcePath: $ReadOnlyArray<string>,
+      resourceArgs: T
+    ) => Promise<T>,
+    after?: <T>(resourcePath: $ReadOnlyArray<string>, response: T) => Promise<T>
+  |}
 |};
 
 /**
@@ -62,1319 +65,1843 @@ type ResourcesType = SWAPIClientlibTypes;
  */
 
 export type LoadersType = $ReadOnly<{|
-    getPlanets: DataLoader<
-        {|
-            ...$Diff<
-                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
-                {
-                    planet_ids: $PropertyType<
-                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
-                        'planet_ids',
-                    >,
-                },
-            >,
-            ...{|
-                planet_id: $ElementType<
-                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>, 'planet_ids'>,
-                    0,
-                >,
-            |},
-        |},
-        $ElementType<
-            $Call<
-                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>]>,
-                $PropertyType<ResourcesType, 'getPlanets'>,
-            >,
-            0,
+  getPlanets: DataLoader<
+    {|
+      ...$Diff<
+        $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
+        {
+          planet_ids: $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
+            "planet_ids"
+          >
+        }
+      >,
+      ...{|
+        planet_id: $ElementType<
+          $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
+            "planet_ids"
+          >,
+          0
+        >
+      |}
+    |},
+    $ElementType<
+      $Call<
+        ExtractPromisedReturnValue<
+          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>]
         >,
-        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-        string,
+        $PropertyType<ResourcesType, "getPlanets">
+      >,
+      0
     >,
-    getPeople: DataLoader<
-        {|
-            ...$Diff<
-                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
-                {
-                    people_ids: $PropertyType<
-                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
-                        'people_ids',
-                    >,
-                },
-            >,
-            ...{|
-                person_id: $ElementType<
-                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>, 'people_ids'>,
-                    0,
-                >,
-            |},
-        |},
-        $ElementType<
-            $Call<
-                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>]>,
-                $PropertyType<ResourcesType, 'getPeople'>,
-            >,
-            0,
+    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+    string
+  >,
+  getPeople: DataLoader<
+    {|
+      ...$Diff<
+        $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
+        {
+          people_ids: $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
+            "people_ids"
+          >
+        }
+      >,
+      ...{|
+        person_id: $ElementType<
+          $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
+            "people_ids"
+          >,
+          0
+        >
+      |}
+    |},
+    $ElementType<
+      $Call<
+        ExtractPromisedReturnValue<
+          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>]
         >,
-        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-        string,
+        $PropertyType<ResourcesType, "getPeople">
+      >,
+      0
     >,
-    getVehicles: DataLoader<
-        {|
-            ...$Diff<
-                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
-                {
-                    vehicle_ids: $PropertyType<
-                        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
-                        'vehicle_ids',
-                    >,
-                },
-            >,
-            ...{|
-                vehicle_id: $ElementType<
-                    $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>, 'vehicle_ids'>,
-                    0,
-                >,
-            |},
-        |},
-        $ElementType<
-            $Call<
-                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>]>,
-                $PropertyType<ResourcesType, 'getVehicles'>,
-            >,
-            0,
+    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+    string
+  >,
+  getVehicles: DataLoader<
+    {|
+      ...$Diff<
+        $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
+        {
+          vehicle_ids: $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
+            "vehicle_ids"
+          >
+        }
+      >,
+      ...{|
+        vehicle_id: $ElementType<
+          $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
+            "vehicle_ids"
+          >,
+          0
+        >
+      |}
+    |},
+    $ElementType<
+      $Call<
+        ExtractPromisedReturnValue<
+          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>]
         >,
-        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-        string,
+        $PropertyType<ResourcesType, "getVehicles">
+      >,
+      0
     >,
-    getFilms: DataLoader<
-        {|
-            ...$Diff<
-                $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
-                {
-                    film_ids: $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>, 'film_ids'>,
-                },
-            >,
-            ...{|
-                film_id: $Call<
-                    ExtractArg,
-                    [
-                        $PropertyType<
-                            $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>, 'film_ids'>,
-                            'has',
-                        >,
-                    ],
-                >,
-            |},
-        |},
-        $ElementType<
-            $Call<
-                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>]>,
-                $PropertyType<ResourcesType, 'getFilms'>,
-            >,
-            0,
+    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+    string
+  >,
+  getFilms: DataLoader<
+    {|
+      ...$Diff<
+        $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
+        {
+          film_ids: $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
+            "film_ids"
+          >
+        }
+      >,
+      ...{|
+        film_id: $Call<
+          ExtractArg,
+          [
+            $PropertyType<
+              $PropertyType<
+                $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
+                "film_ids"
+              >,
+              "has"
+            >
+          ]
+        >
+      |}
+    |},
+    $ElementType<
+      $Call<
+        ExtractPromisedReturnValue<
+          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>]
         >,
-        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-        string,
+        $PropertyType<ResourcesType, "getFilms">
+      >,
+      0
     >,
-    getRoot: DataLoader<
-        $Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>,
+    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+    string
+  >,
+  getFilmsV2: DataLoader<
+    {|
+      ...$Diff<
+        $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
+        {
+          film_ids: $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
+            "film_ids"
+          >
+        }
+      >,
+      ...{|
+        film_id: $ElementType<
+          $PropertyType<
+            $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
+            "film_ids"
+          >,
+          0
+        >
+      |}
+    |},
+    $ElementType<
+      $PropertyType<
         $Call<
-            ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>]>,
-            $PropertyType<ResourcesType, 'getRoot'>,
+          ExtractPromisedReturnValue<
+            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>]
+          >,
+          $PropertyType<ResourcesType, "getFilmsV2">
         >,
-        // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-        string,
+        "properties"
+      >,
+      0
     >,
+    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+    string
+  >,
+  getRoot: DataLoader<
+    $Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>,
+    $Call<
+      ExtractPromisedReturnValue<
+        [$Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>]
+      >,
+      $PropertyType<ResourcesType, "getRoot">
+    >,
+    // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+    string
+  >
 |}>;
 
-export default function getLoaders(resources: ResourcesType, options?: DataLoaderCodegenOptions): LoadersType {
-    return Object.freeze({
-        getPlanets: new DataLoader<
-            {|
-                ...$Diff<
-                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
-                    {
-                        planet_ids: $PropertyType<
-                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>,
-                            'planet_ids',
-                        >,
-                    },
-                >,
-                ...{|
-                    planet_id: $ElementType<
-                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>, 'planet_ids'>,
-                        0,
-                    >,
-                |},
-            |},
-            $ElementType<
-                $Call<
-                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPlanets'>]>]>,
-                    $PropertyType<ResourcesType, 'getPlanets'>,
-                >,
-                0,
+export default function getLoaders(
+  resources: ResourcesType,
+  options?: DataLoaderCodegenOptions
+): LoadersType {
+  return Object.freeze({
+    getPlanets: new DataLoader<
+      {|
+        ...$Diff<
+          $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
+          {
+            planet_ids: $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
+              "planet_ids"
+            >
+          }
+        >,
+        ...{|
+          planet_id: $ElementType<
+            $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>,
+              "planet_ids"
             >,
-            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-            string,
-        >(
+            0
+          >
+        |}
+      |},
+      $ElementType<
+        $Call<
+          ExtractPromisedReturnValue<
+            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPlanets">]>]
+          >,
+          $PropertyType<ResourcesType, "getPlanets">
+        >,
+        0
+      >,
+      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+      string
+    >(
+      /**
+       * ===============================================================
+       * Generated DataLoader: getPlanets
+       * ===============================================================
+       *
+       * Resource Config:
+       *
+       * ```json
+       * {
+       *   "docsLink": "https://swapi.dev/documentation#planets",
+       *   "isBatchResource": true,
+       *   "batchKey": "planet_ids",
+       *   "newKey": "planet_id"
+       * }
+       * ```
+       */
+      async keys => {
+        invariant(
+          typeof resources.getPlanets === "function",
+          [
+            "[dataloader-codegen :: getPlanets] resources.getPlanets is not a function.",
+            'Did you pass in an instance of getPlanets to "getLoaders"?'
+          ].join(" ")
+        );
+
+        /**
+         * Chunk up the "keys" array to create a set of "request groups".
+         *
+         * We're about to hit a batch resource. In addition to the batch
+         * key, the resource may take other arguments too. When batching
+         * up requests, we'll want to look out for where those other
+         * arguments differ, and send multiple requests so we don't get
+         * back the wrong info.
+         *
+         * In other words, we'll potentially want to send _multiple_
+         * requests to the underlying resource batch method in this
+         * dataloader body.
+         *
+         * ~~~ Why? ~~~
+         *
+         * Consider what happens when we get called with arguments where
+         * the non-batch keys differ.
+         *
+         * Example:
+         *
+         * ```js
+         * loaders.foo.load({ foo_id: 2, include_private_data: true });
+         * loaders.foo.load({ foo_id: 3, include_private_data: false });
+         * loaders.foo.load({ foo_id: 4, include_private_data: false });
+         * ```
+         *
+         * If we collected everything up and tried to send the one
+         * request to the resource as a batch request, how do we know
+         * what the value for "include_private_data" should be? We're
+         * going to have to group these up up and send two requests to
+         * the resource to make sure we're requesting the right stuff.
+         *
+         * e.g. We'd need to make the following set of underlying resource
+         * calls:
+         *
+         * ```js
+         * foo({ foo_ids: [ 2 ], include_private_data: true });
+         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+         * ```
+         *
+         * ~~~ tl;dr ~~~
+         *
+         * When we have calls to .load with differing non batch key args,
+         * we'll need to send multiple requests to the underlying
+         * resource to make sure we get the right results back.
+         *
+         * Let's create the request groups, where each element in the
+         * group refers to a position in "keys" (i.e. a call to .load)
+         *
+         * Example:
+         *
+         * ```js
+         * partitionItems([
+         *   { bar_id: 7, include_extra_info: true },
+         *   { bar_id: 8, include_extra_info: false },
+         *   { bar_id: 9, include_extra_info: true },
+         * ], 'bar_id')
+         * ```
+         *
+         * Returns:
+         * `[ [ 0, 2 ], [ 1 ] ]`
+         *
+         * We'll refer to each element in the group as a "request ID".
+         */
+        const requestGroups = partitionItems("planet_id", keys);
+
+        // Map the request groups to a list of Promises - one for each request
+        const groupedResults = await Promise.all(
+          requestGroups.map(async requestIDs => {
             /**
-             * ===============================================================
-             * Generated DataLoader: getPlanets
-             * ===============================================================
+             * Select a set of elements in "keys", where all non-batch
+             * keys should be identical.
              *
-             * Resource Config:
-             *
-             * ```json
-             * {
-             *   "docsLink": "https://swapi.dev/documentation#planets",
-             *   "isBatchResource": true,
-             *   "batchKey": "planet_ids",
-             *   "newKey": "planet_id"
-             * }
-             * ```
+             * We're going to smoosh all these together into one payload to
+             * send to the resource as a batch request!
              */
-            async (keys) => {
-                invariant(
-                    typeof resources.getPlanets === 'function',
-                    [
-                        '[dataloader-codegen :: getPlanets] resources.getPlanets is not a function.',
-                        'Did you pass in an instance of getPlanets to "getLoaders"?',
-                    ].join(' '),
+            const requests = requestIDs.map(id => keys[id]);
+
+            // For now, we assume that the dataloader key should be the first argument to the resource
+            // @see https://github.com/Yelp/dataloader-codegen/issues/56
+            const resourceArgs = [
+              {
+                ..._.omit(requests[0], "planet_id"),
+                ["planet_ids"]: requests.map(k => k["planet_id"])
+              }
+            ];
+
+            let response = await (async _resourceArgs => {
+              // Make a re-assignable variable so flow/eslint doesn't complain
+              let __resourceArgs = _resourceArgs;
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.before
+              ) {
+                __resourceArgs = await options.resourceMiddleware.before(
+                  ["getPlanets"],
+                  __resourceArgs
                 );
+              }
+
+              let _response;
+              try {
+                // Finally, call the resource!
+                _response = await resources.getPlanets(...__resourceArgs);
+              } catch (error) {
+                const errorHandler =
+                  options && typeof options.errorHandler === "function"
+                    ? options.errorHandler
+                    : defaultErrorHandler;
 
                 /**
-                 * Chunk up the "keys" array to create a set of "request groups".
+                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
                  *
-                 * We're about to hit a batch resource. In addition to the batch
-                 * key, the resource may take other arguments too. When batching
-                 * up requests, we'll want to look out for where those other
-                 * arguments differ, and send multiple requests so we don't get
-                 * back the wrong info.
-                 *
-                 * In other words, we'll potentially want to send _multiple_
-                 * requests to the underlying resource batch method in this
-                 * dataloader body.
-                 *
-                 * ~~~ Why? ~~~
-                 *
-                 * Consider what happens when we get called with arguments where
-                 * the non-batch keys differ.
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
-                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
-                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
-                 * ```
-                 *
-                 * If we collected everything up and tried to send the one
-                 * request to the resource as a batch request, how do we know
-                 * what the value for "include_private_data" should be? We're
-                 * going to have to group these up up and send two requests to
-                 * the resource to make sure we're requesting the right stuff.
-                 *
-                 * e.g. We'd need to make the following set of underlying resource
-                 * calls:
-                 *
-                 * ```js
-                 * foo({ foo_ids: [ 2 ], include_private_data: true });
-                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-                 * ```
-                 *
-                 * ~~~ tl;dr ~~~
-                 *
-                 * When we have calls to .load with differing non batch key args,
-                 * we'll need to send multiple requests to the underlying
-                 * resource to make sure we get the right results back.
-                 *
-                 * Let's create the request groups, where each element in the
-                 * group refers to a position in "keys" (i.e. a call to .load)
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * partitionItems([
-                 *   { bar_id: 7, include_extra_info: true },
-                 *   { bar_id: 8, include_extra_info: false },
-                 *   { bar_id: 9, include_extra_info: true },
-                 * ], 'bar_id')
-                 * ```
-                 *
-                 * Returns:
-                 * `[ [ 0, 2 ], [ 1 ] ]`
-                 *
-                 * We'll refer to each element in the group as a "request ID".
+                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
                  */
-                const requestGroups = partitionItems('planet_id', keys);
+                _response = await errorHandler(["getPlanets"], error);
 
-                // Map the request groups to a list of Promises - one for each request
-                const groupedResults = await Promise.all(
-                    requestGroups.map(async (requestIDs) => {
-                        /**
-                         * Select a set of elements in "keys", where all non-batch
-                         * keys should be identical.
-                         *
-                         * We're going to smoosh all these together into one payload to
-                         * send to the resource as a batch request!
-                         */
-                        const requests = requestIDs.map((id) => keys[id]);
-
-                        // For now, we assume that the dataloader key should be the first argument to the resource
-                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
-                        const resourceArgs = [
-                            {
-                                ..._.omit(requests[0], 'planet_id'),
-                                ['planet_ids']: requests.map((k) => k['planet_id']),
-                            },
-                        ];
-
-                        let response = await (async (_resourceArgs) => {
-                            // Make a re-assignable variable so flow/eslint doesn't complain
-                            let __resourceArgs = _resourceArgs;
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
-                                __resourceArgs = await options.resourceMiddleware.before(
-                                    ['getPlanets'],
-                                    __resourceArgs,
-                                );
-                            }
-
-                            let _response;
-                            try {
-                                // Finally, call the resource!
-                                _response = await resources.getPlanets(...__resourceArgs);
-                            } catch (error) {
-                                const errorHandler =
-                                    options && typeof options.errorHandler === 'function'
-                                        ? options.errorHandler
-                                        : defaultErrorHandler;
-
-                                /**
-                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                                 *
-                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                                 */
-                                _response = await errorHandler(['getPlanets'], error);
-
-                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                                if (!(_response instanceof Error)) {
-                                    _response = new Error(
-                                        [
-                                            `[dataloader-codegen :: getPlanets] Caught an error, but errorHandler did not return an Error object.`,
-                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
-                                        ].join(' '),
-                                    );
-                                }
-                            }
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
-                                _response = await options.resourceMiddleware.after(['getPlanets'], _response);
-                            }
-
-                            return _response;
-                        })(resourceArgs);
-
-                        if (!(response instanceof Error)) {
-                        }
-
-                        if (!(response instanceof Error)) {
-                            if (!Array.isArray(response)) {
-                                response = new Error(
-                                    ['[dataloader-codegen :: getPlanets]', 'Expected response to be an array!'].join(
-                                        ' ',
-                                    ),
-                                );
-                            }
-                        }
-
-                        if (!(response instanceof Error)) {
-                            /**
-                             * Check to see the resource contains the same number
-                             * of items that we requested. If not, since there's
-                             * no "reorderResultsByKey" specified for this resource,
-                             * we don't know _which_ key's response is missing. Therefore
-                             * it's unsafe to return the response array back.
-                             */
-                            if (response.length !== requests.length) {
-                                /**
-                                 * We must return errors for all keys in this group :(
-                                 */
-                                response = new BatchItemNotFoundError(
-                                    [
-                                        `[dataloader-codegen :: getPlanets] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
-                                    ].join(' '),
-                                );
-
-                                // Tell flow that BatchItemNotFoundError extends Error.
-                                // It's an issue with flowgen package, but not an issue with Flow.
-                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
-                            }
-                        }
-
-                        /**
-                         * If the resource returns an Error, we'll want to copy and
-                         * return that error as the return value for every request in
-                         * this group.
-                         *
-                         * This allow the error to be cached, and allows the rest of the
-                         * requests made by this DataLoader to succeed.
-                         *
-                         * @see https://github.com/graphql/dataloader#caching-errors
-                         */
-                        if (response instanceof Error) {
-                            response = requestIDs.map((requestId) => {
-                                /**
-                                 * Since we're returning an error object and not the
-                                 * expected return type from the resource, this element
-                                 * would be unsortable, since it wouldn't have the
-                                 * "reorderResultsByKey" attribute.
-                                 *
-                                 * Let's add it to the error object, as "reorderResultsByValue".
-                                 *
-                                 * (If we didn't specify that this resource needs
-                                 * sorting, then this will be "null" and won't be used.)
-                                 */
-                                const reorderResultsByValue = null;
-
-                                // Tell flow that "response" is actually an error object.
-                                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                                invariant(response instanceof Error, 'expected response to be an error');
-
-                                return new CaughtResourceError(
-                                    `[dataloader-codegen :: getPlanets] Caught error during call to resource. Error: ${response.stack}`,
-                                    response,
-                                    reorderResultsByValue,
-                                );
-                            });
-                        }
-
-                        return response;
-                    }),
-                );
-
-                // Split the results back up into the order that they were requested
-                return unPartitionResults(requestGroups, groupedResults);
-            },
-            {
-                ...cacheKeyOptions,
-            },
-        ),
-        getPeople: new DataLoader<
-            {|
-                ...$Diff<
-                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
-                    {
-                        people_ids: $PropertyType<
-                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>,
-                            'people_ids',
-                        >,
-                    },
-                >,
-                ...{|
-                    person_id: $ElementType<
-                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>, 'people_ids'>,
-                        0,
-                    >,
-                |},
-            |},
-            $ElementType<
-                $Call<
-                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getPeople'>]>]>,
-                    $PropertyType<ResourcesType, 'getPeople'>,
-                >,
-                0,
-            >,
-            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-            string,
-        >(
-            /**
-             * ===============================================================
-             * Generated DataLoader: getPeople
-             * ===============================================================
-             *
-             * Resource Config:
-             *
-             * ```json
-             * {
-             *   "docsLink": "https://swapi.dev/documentation#people",
-             *   "isBatchResource": true,
-             *   "batchKey": "people_ids",
-             *   "newKey": "person_id"
-             * }
-             * ```
-             */
-            async (keys) => {
-                invariant(
-                    typeof resources.getPeople === 'function',
+                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                if (!(_response instanceof Error)) {
+                  _response = new Error(
                     [
-                        '[dataloader-codegen :: getPeople] resources.getPeople is not a function.',
-                        'Did you pass in an instance of getPeople to "getLoaders"?',
-                    ].join(' '),
+                      `[dataloader-codegen :: getPlanets] Caught an error, but errorHandler did not return an Error object.`,
+                      `Instead, got ${typeof _response}: ${util.inspect(
+                        _response
+                      )}`
+                    ].join(" ")
+                  );
+                }
+              }
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.after
+              ) {
+                _response = await options.resourceMiddleware.after(
+                  ["getPlanets"],
+                  _response
                 );
+              }
+
+              return _response;
+            })(resourceArgs);
+
+            if (!(response instanceof Error)) {
+            }
+
+            if (!(response instanceof Error)) {
+              if (!Array.isArray(response)) {
+                response = new Error(
+                  [
+                    "[dataloader-codegen :: getPlanets]",
+                    "Expected response to be an array!"
+                  ].join(" ")
+                );
+              }
+            }
+
+            if (!(response instanceof Error)) {
+              /**
+               * Check to see the resource contains the same number
+               * of items that we requested. If not, since there's
+               * no "reorderResultsByKey" specified for this resource,
+               * we don't know _which_ key's response is missing. Therefore
+               * it's unsafe to return the response array back.
+               */
+              if (response.length !== requests.length) {
+                /**
+                 * We must return errors for all keys in this group :(
+                 */
+                response = new BatchItemNotFoundError(
+                  [
+                    `[dataloader-codegen :: getPlanets] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
+                  ].join(" ")
+                );
+
+                // Tell flow that BatchItemNotFoundError extends Error.
+                // It's an issue with flowgen package, but not an issue with Flow.
+                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                invariant(
+                  response instanceof Error,
+                  "expected BatchItemNotFoundError to be an Error"
+                );
+              }
+            }
+
+            /**
+             * If the resource returns an Error, we'll want to copy and
+             * return that error as the return value for every request in
+             * this group.
+             *
+             * This allow the error to be cached, and allows the rest of the
+             * requests made by this DataLoader to succeed.
+             *
+             * @see https://github.com/graphql/dataloader#caching-errors
+             */
+            if (response instanceof Error) {
+              response = requestIDs.map(requestId => {
+                /**
+                 * Since we're returning an error object and not the
+                 * expected return type from the resource, this element
+                 * would be unsortable, since it wouldn't have the
+                 * "reorderResultsByKey" attribute.
+                 *
+                 * Let's add it to the error object, as "reorderResultsByValue".
+                 *
+                 * (If we didn't specify that this resource needs
+                 * sorting, then this will be "null" and won't be used.)
+                 */
+                const reorderResultsByValue = null;
+
+                // Tell flow that "response" is actually an error object.
+                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                invariant(
+                  response instanceof Error,
+                  "expected response to be an error"
+                );
+
+                return new CaughtResourceError(
+                  `[dataloader-codegen :: getPlanets] Caught error during call to resource. Error: ${response.stack}`,
+                  response,
+                  reorderResultsByValue
+                );
+              });
+            }
+
+            return response;
+          })
+        );
+
+        // Split the results back up into the order that they were requested
+        return unPartitionResults(requestGroups, groupedResults);
+      },
+      {
+        ...cacheKeyOptions
+      }
+    ),
+    getPeople: new DataLoader<
+      {|
+        ...$Diff<
+          $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
+          {
+            people_ids: $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
+              "people_ids"
+            >
+          }
+        >,
+        ...{|
+          person_id: $ElementType<
+            $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>,
+              "people_ids"
+            >,
+            0
+          >
+        |}
+      |},
+      $ElementType<
+        $Call<
+          ExtractPromisedReturnValue<
+            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getPeople">]>]
+          >,
+          $PropertyType<ResourcesType, "getPeople">
+        >,
+        0
+      >,
+      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+      string
+    >(
+      /**
+       * ===============================================================
+       * Generated DataLoader: getPeople
+       * ===============================================================
+       *
+       * Resource Config:
+       *
+       * ```json
+       * {
+       *   "docsLink": "https://swapi.dev/documentation#people",
+       *   "isBatchResource": true,
+       *   "batchKey": "people_ids",
+       *   "newKey": "person_id"
+       * }
+       * ```
+       */
+      async keys => {
+        invariant(
+          typeof resources.getPeople === "function",
+          [
+            "[dataloader-codegen :: getPeople] resources.getPeople is not a function.",
+            'Did you pass in an instance of getPeople to "getLoaders"?'
+          ].join(" ")
+        );
+
+        /**
+         * Chunk up the "keys" array to create a set of "request groups".
+         *
+         * We're about to hit a batch resource. In addition to the batch
+         * key, the resource may take other arguments too. When batching
+         * up requests, we'll want to look out for where those other
+         * arguments differ, and send multiple requests so we don't get
+         * back the wrong info.
+         *
+         * In other words, we'll potentially want to send _multiple_
+         * requests to the underlying resource batch method in this
+         * dataloader body.
+         *
+         * ~~~ Why? ~~~
+         *
+         * Consider what happens when we get called with arguments where
+         * the non-batch keys differ.
+         *
+         * Example:
+         *
+         * ```js
+         * loaders.foo.load({ foo_id: 2, include_private_data: true });
+         * loaders.foo.load({ foo_id: 3, include_private_data: false });
+         * loaders.foo.load({ foo_id: 4, include_private_data: false });
+         * ```
+         *
+         * If we collected everything up and tried to send the one
+         * request to the resource as a batch request, how do we know
+         * what the value for "include_private_data" should be? We're
+         * going to have to group these up up and send two requests to
+         * the resource to make sure we're requesting the right stuff.
+         *
+         * e.g. We'd need to make the following set of underlying resource
+         * calls:
+         *
+         * ```js
+         * foo({ foo_ids: [ 2 ], include_private_data: true });
+         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+         * ```
+         *
+         * ~~~ tl;dr ~~~
+         *
+         * When we have calls to .load with differing non batch key args,
+         * we'll need to send multiple requests to the underlying
+         * resource to make sure we get the right results back.
+         *
+         * Let's create the request groups, where each element in the
+         * group refers to a position in "keys" (i.e. a call to .load)
+         *
+         * Example:
+         *
+         * ```js
+         * partitionItems([
+         *   { bar_id: 7, include_extra_info: true },
+         *   { bar_id: 8, include_extra_info: false },
+         *   { bar_id: 9, include_extra_info: true },
+         * ], 'bar_id')
+         * ```
+         *
+         * Returns:
+         * `[ [ 0, 2 ], [ 1 ] ]`
+         *
+         * We'll refer to each element in the group as a "request ID".
+         */
+        const requestGroups = partitionItems("person_id", keys);
+
+        // Map the request groups to a list of Promises - one for each request
+        const groupedResults = await Promise.all(
+          requestGroups.map(async requestIDs => {
+            /**
+             * Select a set of elements in "keys", where all non-batch
+             * keys should be identical.
+             *
+             * We're going to smoosh all these together into one payload to
+             * send to the resource as a batch request!
+             */
+            const requests = requestIDs.map(id => keys[id]);
+
+            // For now, we assume that the dataloader key should be the first argument to the resource
+            // @see https://github.com/Yelp/dataloader-codegen/issues/56
+            const resourceArgs = [
+              {
+                ..._.omit(requests[0], "person_id"),
+                ["people_ids"]: requests.map(k => k["person_id"])
+              }
+            ];
+
+            let response = await (async _resourceArgs => {
+              // Make a re-assignable variable so flow/eslint doesn't complain
+              let __resourceArgs = _resourceArgs;
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.before
+              ) {
+                __resourceArgs = await options.resourceMiddleware.before(
+                  ["getPeople"],
+                  __resourceArgs
+                );
+              }
+
+              let _response;
+              try {
+                // Finally, call the resource!
+                _response = await resources.getPeople(...__resourceArgs);
+              } catch (error) {
+                const errorHandler =
+                  options && typeof options.errorHandler === "function"
+                    ? options.errorHandler
+                    : defaultErrorHandler;
 
                 /**
-                 * Chunk up the "keys" array to create a set of "request groups".
+                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
                  *
-                 * We're about to hit a batch resource. In addition to the batch
-                 * key, the resource may take other arguments too. When batching
-                 * up requests, we'll want to look out for where those other
-                 * arguments differ, and send multiple requests so we don't get
-                 * back the wrong info.
-                 *
-                 * In other words, we'll potentially want to send _multiple_
-                 * requests to the underlying resource batch method in this
-                 * dataloader body.
-                 *
-                 * ~~~ Why? ~~~
-                 *
-                 * Consider what happens when we get called with arguments where
-                 * the non-batch keys differ.
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
-                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
-                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
-                 * ```
-                 *
-                 * If we collected everything up and tried to send the one
-                 * request to the resource as a batch request, how do we know
-                 * what the value for "include_private_data" should be? We're
-                 * going to have to group these up up and send two requests to
-                 * the resource to make sure we're requesting the right stuff.
-                 *
-                 * e.g. We'd need to make the following set of underlying resource
-                 * calls:
-                 *
-                 * ```js
-                 * foo({ foo_ids: [ 2 ], include_private_data: true });
-                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-                 * ```
-                 *
-                 * ~~~ tl;dr ~~~
-                 *
-                 * When we have calls to .load with differing non batch key args,
-                 * we'll need to send multiple requests to the underlying
-                 * resource to make sure we get the right results back.
-                 *
-                 * Let's create the request groups, where each element in the
-                 * group refers to a position in "keys" (i.e. a call to .load)
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * partitionItems([
-                 *   { bar_id: 7, include_extra_info: true },
-                 *   { bar_id: 8, include_extra_info: false },
-                 *   { bar_id: 9, include_extra_info: true },
-                 * ], 'bar_id')
-                 * ```
-                 *
-                 * Returns:
-                 * `[ [ 0, 2 ], [ 1 ] ]`
-                 *
-                 * We'll refer to each element in the group as a "request ID".
+                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
                  */
-                const requestGroups = partitionItems('person_id', keys);
+                _response = await errorHandler(["getPeople"], error);
 
-                // Map the request groups to a list of Promises - one for each request
-                const groupedResults = await Promise.all(
-                    requestGroups.map(async (requestIDs) => {
-                        /**
-                         * Select a set of elements in "keys", where all non-batch
-                         * keys should be identical.
-                         *
-                         * We're going to smoosh all these together into one payload to
-                         * send to the resource as a batch request!
-                         */
-                        const requests = requestIDs.map((id) => keys[id]);
-
-                        // For now, we assume that the dataloader key should be the first argument to the resource
-                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
-                        const resourceArgs = [
-                            {
-                                ..._.omit(requests[0], 'person_id'),
-                                ['people_ids']: requests.map((k) => k['person_id']),
-                            },
-                        ];
-
-                        let response = await (async (_resourceArgs) => {
-                            // Make a re-assignable variable so flow/eslint doesn't complain
-                            let __resourceArgs = _resourceArgs;
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
-                                __resourceArgs = await options.resourceMiddleware.before(['getPeople'], __resourceArgs);
-                            }
-
-                            let _response;
-                            try {
-                                // Finally, call the resource!
-                                _response = await resources.getPeople(...__resourceArgs);
-                            } catch (error) {
-                                const errorHandler =
-                                    options && typeof options.errorHandler === 'function'
-                                        ? options.errorHandler
-                                        : defaultErrorHandler;
-
-                                /**
-                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                                 *
-                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                                 */
-                                _response = await errorHandler(['getPeople'], error);
-
-                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                                if (!(_response instanceof Error)) {
-                                    _response = new Error(
-                                        [
-                                            `[dataloader-codegen :: getPeople] Caught an error, but errorHandler did not return an Error object.`,
-                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
-                                        ].join(' '),
-                                    );
-                                }
-                            }
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
-                                _response = await options.resourceMiddleware.after(['getPeople'], _response);
-                            }
-
-                            return _response;
-                        })(resourceArgs);
-
-                        if (!(response instanceof Error)) {
-                        }
-
-                        if (!(response instanceof Error)) {
-                            if (!Array.isArray(response)) {
-                                response = new Error(
-                                    ['[dataloader-codegen :: getPeople]', 'Expected response to be an array!'].join(
-                                        ' ',
-                                    ),
-                                );
-                            }
-                        }
-
-                        if (!(response instanceof Error)) {
-                            /**
-                             * Check to see the resource contains the same number
-                             * of items that we requested. If not, since there's
-                             * no "reorderResultsByKey" specified for this resource,
-                             * we don't know _which_ key's response is missing. Therefore
-                             * it's unsafe to return the response array back.
-                             */
-                            if (response.length !== requests.length) {
-                                /**
-                                 * We must return errors for all keys in this group :(
-                                 */
-                                response = new BatchItemNotFoundError(
-                                    [
-                                        `[dataloader-codegen :: getPeople] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
-                                    ].join(' '),
-                                );
-
-                                // Tell flow that BatchItemNotFoundError extends Error.
-                                // It's an issue with flowgen package, but not an issue with Flow.
-                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
-                            }
-                        }
-
-                        /**
-                         * If the resource returns an Error, we'll want to copy and
-                         * return that error as the return value for every request in
-                         * this group.
-                         *
-                         * This allow the error to be cached, and allows the rest of the
-                         * requests made by this DataLoader to succeed.
-                         *
-                         * @see https://github.com/graphql/dataloader#caching-errors
-                         */
-                        if (response instanceof Error) {
-                            response = requestIDs.map((requestId) => {
-                                /**
-                                 * Since we're returning an error object and not the
-                                 * expected return type from the resource, this element
-                                 * would be unsortable, since it wouldn't have the
-                                 * "reorderResultsByKey" attribute.
-                                 *
-                                 * Let's add it to the error object, as "reorderResultsByValue".
-                                 *
-                                 * (If we didn't specify that this resource needs
-                                 * sorting, then this will be "null" and won't be used.)
-                                 */
-                                const reorderResultsByValue = null;
-
-                                // Tell flow that "response" is actually an error object.
-                                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                                invariant(response instanceof Error, 'expected response to be an error');
-
-                                return new CaughtResourceError(
-                                    `[dataloader-codegen :: getPeople] Caught error during call to resource. Error: ${response.stack}`,
-                                    response,
-                                    reorderResultsByValue,
-                                );
-                            });
-                        }
-
-                        return response;
-                    }),
-                );
-
-                // Split the results back up into the order that they were requested
-                return unPartitionResults(requestGroups, groupedResults);
-            },
-            {
-                ...cacheKeyOptions,
-            },
-        ),
-        getVehicles: new DataLoader<
-            {|
-                ...$Diff<
-                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
-                    {
-                        vehicle_ids: $PropertyType<
-                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>,
-                            'vehicle_ids',
-                        >,
-                    },
-                >,
-                ...{|
-                    vehicle_id: $ElementType<
-                        $PropertyType<$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>, 'vehicle_ids'>,
-                        0,
-                    >,
-                |},
-            |},
-            $ElementType<
-                $Call<
-                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getVehicles'>]>]>,
-                    $PropertyType<ResourcesType, 'getVehicles'>,
-                >,
-                0,
-            >,
-            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-            string,
-        >(
-            /**
-             * ===============================================================
-             * Generated DataLoader: getVehicles
-             * ===============================================================
-             *
-             * Resource Config:
-             *
-             * ```json
-             * {
-             *   "docsLink": "https://swapi.dev/documentation#vehicles",
-             *   "isBatchResource": true,
-             *   "batchKey": "vehicle_ids",
-             *   "newKey": "vehicle_id"
-             * }
-             * ```
-             */
-            async (keys) => {
-                invariant(
-                    typeof resources.getVehicles === 'function',
+                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                if (!(_response instanceof Error)) {
+                  _response = new Error(
                     [
-                        '[dataloader-codegen :: getVehicles] resources.getVehicles is not a function.',
-                        'Did you pass in an instance of getVehicles to "getLoaders"?',
-                    ].join(' '),
+                      `[dataloader-codegen :: getPeople] Caught an error, but errorHandler did not return an Error object.`,
+                      `Instead, got ${typeof _response}: ${util.inspect(
+                        _response
+                      )}`
+                    ].join(" ")
+                  );
+                }
+              }
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.after
+              ) {
+                _response = await options.resourceMiddleware.after(
+                  ["getPeople"],
+                  _response
                 );
+              }
+
+              return _response;
+            })(resourceArgs);
+
+            if (!(response instanceof Error)) {
+            }
+
+            if (!(response instanceof Error)) {
+              if (!Array.isArray(response)) {
+                response = new Error(
+                  [
+                    "[dataloader-codegen :: getPeople]",
+                    "Expected response to be an array!"
+                  ].join(" ")
+                );
+              }
+            }
+
+            if (!(response instanceof Error)) {
+              /**
+               * Check to see the resource contains the same number
+               * of items that we requested. If not, since there's
+               * no "reorderResultsByKey" specified for this resource,
+               * we don't know _which_ key's response is missing. Therefore
+               * it's unsafe to return the response array back.
+               */
+              if (response.length !== requests.length) {
+                /**
+                 * We must return errors for all keys in this group :(
+                 */
+                response = new BatchItemNotFoundError(
+                  [
+                    `[dataloader-codegen :: getPeople] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
+                  ].join(" ")
+                );
+
+                // Tell flow that BatchItemNotFoundError extends Error.
+                // It's an issue with flowgen package, but not an issue with Flow.
+                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                invariant(
+                  response instanceof Error,
+                  "expected BatchItemNotFoundError to be an Error"
+                );
+              }
+            }
+
+            /**
+             * If the resource returns an Error, we'll want to copy and
+             * return that error as the return value for every request in
+             * this group.
+             *
+             * This allow the error to be cached, and allows the rest of the
+             * requests made by this DataLoader to succeed.
+             *
+             * @see https://github.com/graphql/dataloader#caching-errors
+             */
+            if (response instanceof Error) {
+              response = requestIDs.map(requestId => {
+                /**
+                 * Since we're returning an error object and not the
+                 * expected return type from the resource, this element
+                 * would be unsortable, since it wouldn't have the
+                 * "reorderResultsByKey" attribute.
+                 *
+                 * Let's add it to the error object, as "reorderResultsByValue".
+                 *
+                 * (If we didn't specify that this resource needs
+                 * sorting, then this will be "null" and won't be used.)
+                 */
+                const reorderResultsByValue = null;
+
+                // Tell flow that "response" is actually an error object.
+                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                invariant(
+                  response instanceof Error,
+                  "expected response to be an error"
+                );
+
+                return new CaughtResourceError(
+                  `[dataloader-codegen :: getPeople] Caught error during call to resource. Error: ${response.stack}`,
+                  response,
+                  reorderResultsByValue
+                );
+              });
+            }
+
+            return response;
+          })
+        );
+
+        // Split the results back up into the order that they were requested
+        return unPartitionResults(requestGroups, groupedResults);
+      },
+      {
+        ...cacheKeyOptions
+      }
+    ),
+    getVehicles: new DataLoader<
+      {|
+        ...$Diff<
+          $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
+          {
+            vehicle_ids: $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
+              "vehicle_ids"
+            >
+          }
+        >,
+        ...{|
+          vehicle_id: $ElementType<
+            $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>,
+              "vehicle_ids"
+            >,
+            0
+          >
+        |}
+      |},
+      $ElementType<
+        $Call<
+          ExtractPromisedReturnValue<
+            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getVehicles">]>]
+          >,
+          $PropertyType<ResourcesType, "getVehicles">
+        >,
+        0
+      >,
+      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+      string
+    >(
+      /**
+       * ===============================================================
+       * Generated DataLoader: getVehicles
+       * ===============================================================
+       *
+       * Resource Config:
+       *
+       * ```json
+       * {
+       *   "docsLink": "https://swapi.dev/documentation#vehicles",
+       *   "isBatchResource": true,
+       *   "batchKey": "vehicle_ids",
+       *   "newKey": "vehicle_id"
+       * }
+       * ```
+       */
+      async keys => {
+        invariant(
+          typeof resources.getVehicles === "function",
+          [
+            "[dataloader-codegen :: getVehicles] resources.getVehicles is not a function.",
+            'Did you pass in an instance of getVehicles to "getLoaders"?'
+          ].join(" ")
+        );
+
+        /**
+         * Chunk up the "keys" array to create a set of "request groups".
+         *
+         * We're about to hit a batch resource. In addition to the batch
+         * key, the resource may take other arguments too. When batching
+         * up requests, we'll want to look out for where those other
+         * arguments differ, and send multiple requests so we don't get
+         * back the wrong info.
+         *
+         * In other words, we'll potentially want to send _multiple_
+         * requests to the underlying resource batch method in this
+         * dataloader body.
+         *
+         * ~~~ Why? ~~~
+         *
+         * Consider what happens when we get called with arguments where
+         * the non-batch keys differ.
+         *
+         * Example:
+         *
+         * ```js
+         * loaders.foo.load({ foo_id: 2, include_private_data: true });
+         * loaders.foo.load({ foo_id: 3, include_private_data: false });
+         * loaders.foo.load({ foo_id: 4, include_private_data: false });
+         * ```
+         *
+         * If we collected everything up and tried to send the one
+         * request to the resource as a batch request, how do we know
+         * what the value for "include_private_data" should be? We're
+         * going to have to group these up up and send two requests to
+         * the resource to make sure we're requesting the right stuff.
+         *
+         * e.g. We'd need to make the following set of underlying resource
+         * calls:
+         *
+         * ```js
+         * foo({ foo_ids: [ 2 ], include_private_data: true });
+         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+         * ```
+         *
+         * ~~~ tl;dr ~~~
+         *
+         * When we have calls to .load with differing non batch key args,
+         * we'll need to send multiple requests to the underlying
+         * resource to make sure we get the right results back.
+         *
+         * Let's create the request groups, where each element in the
+         * group refers to a position in "keys" (i.e. a call to .load)
+         *
+         * Example:
+         *
+         * ```js
+         * partitionItems([
+         *   { bar_id: 7, include_extra_info: true },
+         *   { bar_id: 8, include_extra_info: false },
+         *   { bar_id: 9, include_extra_info: true },
+         * ], 'bar_id')
+         * ```
+         *
+         * Returns:
+         * `[ [ 0, 2 ], [ 1 ] ]`
+         *
+         * We'll refer to each element in the group as a "request ID".
+         */
+        const requestGroups = partitionItems("vehicle_id", keys);
+
+        // Map the request groups to a list of Promises - one for each request
+        const groupedResults = await Promise.all(
+          requestGroups.map(async requestIDs => {
+            /**
+             * Select a set of elements in "keys", where all non-batch
+             * keys should be identical.
+             *
+             * We're going to smoosh all these together into one payload to
+             * send to the resource as a batch request!
+             */
+            const requests = requestIDs.map(id => keys[id]);
+
+            // For now, we assume that the dataloader key should be the first argument to the resource
+            // @see https://github.com/Yelp/dataloader-codegen/issues/56
+            const resourceArgs = [
+              {
+                ..._.omit(requests[0], "vehicle_id"),
+                ["vehicle_ids"]: requests.map(k => k["vehicle_id"])
+              }
+            ];
+
+            let response = await (async _resourceArgs => {
+              // Make a re-assignable variable so flow/eslint doesn't complain
+              let __resourceArgs = _resourceArgs;
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.before
+              ) {
+                __resourceArgs = await options.resourceMiddleware.before(
+                  ["getVehicles"],
+                  __resourceArgs
+                );
+              }
+
+              let _response;
+              try {
+                // Finally, call the resource!
+                _response = await resources.getVehicles(...__resourceArgs);
+              } catch (error) {
+                const errorHandler =
+                  options && typeof options.errorHandler === "function"
+                    ? options.errorHandler
+                    : defaultErrorHandler;
 
                 /**
-                 * Chunk up the "keys" array to create a set of "request groups".
+                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
                  *
-                 * We're about to hit a batch resource. In addition to the batch
-                 * key, the resource may take other arguments too. When batching
-                 * up requests, we'll want to look out for where those other
-                 * arguments differ, and send multiple requests so we don't get
-                 * back the wrong info.
-                 *
-                 * In other words, we'll potentially want to send _multiple_
-                 * requests to the underlying resource batch method in this
-                 * dataloader body.
-                 *
-                 * ~~~ Why? ~~~
-                 *
-                 * Consider what happens when we get called with arguments where
-                 * the non-batch keys differ.
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
-                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
-                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
-                 * ```
-                 *
-                 * If we collected everything up and tried to send the one
-                 * request to the resource as a batch request, how do we know
-                 * what the value for "include_private_data" should be? We're
-                 * going to have to group these up up and send two requests to
-                 * the resource to make sure we're requesting the right stuff.
-                 *
-                 * e.g. We'd need to make the following set of underlying resource
-                 * calls:
-                 *
-                 * ```js
-                 * foo({ foo_ids: [ 2 ], include_private_data: true });
-                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-                 * ```
-                 *
-                 * ~~~ tl;dr ~~~
-                 *
-                 * When we have calls to .load with differing non batch key args,
-                 * we'll need to send multiple requests to the underlying
-                 * resource to make sure we get the right results back.
-                 *
-                 * Let's create the request groups, where each element in the
-                 * group refers to a position in "keys" (i.e. a call to .load)
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * partitionItems([
-                 *   { bar_id: 7, include_extra_info: true },
-                 *   { bar_id: 8, include_extra_info: false },
-                 *   { bar_id: 9, include_extra_info: true },
-                 * ], 'bar_id')
-                 * ```
-                 *
-                 * Returns:
-                 * `[ [ 0, 2 ], [ 1 ] ]`
-                 *
-                 * We'll refer to each element in the group as a "request ID".
+                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
                  */
-                const requestGroups = partitionItems('vehicle_id', keys);
+                _response = await errorHandler(["getVehicles"], error);
 
-                // Map the request groups to a list of Promises - one for each request
-                const groupedResults = await Promise.all(
-                    requestGroups.map(async (requestIDs) => {
-                        /**
-                         * Select a set of elements in "keys", where all non-batch
-                         * keys should be identical.
-                         *
-                         * We're going to smoosh all these together into one payload to
-                         * send to the resource as a batch request!
-                         */
-                        const requests = requestIDs.map((id) => keys[id]);
-
-                        // For now, we assume that the dataloader key should be the first argument to the resource
-                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
-                        const resourceArgs = [
-                            {
-                                ..._.omit(requests[0], 'vehicle_id'),
-                                ['vehicle_ids']: requests.map((k) => k['vehicle_id']),
-                            },
-                        ];
-
-                        let response = await (async (_resourceArgs) => {
-                            // Make a re-assignable variable so flow/eslint doesn't complain
-                            let __resourceArgs = _resourceArgs;
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
-                                __resourceArgs = await options.resourceMiddleware.before(
-                                    ['getVehicles'],
-                                    __resourceArgs,
-                                );
-                            }
-
-                            let _response;
-                            try {
-                                // Finally, call the resource!
-                                _response = await resources.getVehicles(...__resourceArgs);
-                            } catch (error) {
-                                const errorHandler =
-                                    options && typeof options.errorHandler === 'function'
-                                        ? options.errorHandler
-                                        : defaultErrorHandler;
-
-                                /**
-                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                                 *
-                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                                 */
-                                _response = await errorHandler(['getVehicles'], error);
-
-                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                                if (!(_response instanceof Error)) {
-                                    _response = new Error(
-                                        [
-                                            `[dataloader-codegen :: getVehicles] Caught an error, but errorHandler did not return an Error object.`,
-                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
-                                        ].join(' '),
-                                    );
-                                }
-                            }
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
-                                _response = await options.resourceMiddleware.after(['getVehicles'], _response);
-                            }
-
-                            return _response;
-                        })(resourceArgs);
-
-                        if (!(response instanceof Error)) {
-                        }
-
-                        if (!(response instanceof Error)) {
-                            if (!Array.isArray(response)) {
-                                response = new Error(
-                                    ['[dataloader-codegen :: getVehicles]', 'Expected response to be an array!'].join(
-                                        ' ',
-                                    ),
-                                );
-                            }
-                        }
-
-                        if (!(response instanceof Error)) {
-                            /**
-                             * Check to see the resource contains the same number
-                             * of items that we requested. If not, since there's
-                             * no "reorderResultsByKey" specified for this resource,
-                             * we don't know _which_ key's response is missing. Therefore
-                             * it's unsafe to return the response array back.
-                             */
-                            if (response.length !== requests.length) {
-                                /**
-                                 * We must return errors for all keys in this group :(
-                                 */
-                                response = new BatchItemNotFoundError(
-                                    [
-                                        `[dataloader-codegen :: getVehicles] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
-                                    ].join(' '),
-                                );
-
-                                // Tell flow that BatchItemNotFoundError extends Error.
-                                // It's an issue with flowgen package, but not an issue with Flow.
-                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
-                            }
-                        }
-
-                        /**
-                         * If the resource returns an Error, we'll want to copy and
-                         * return that error as the return value for every request in
-                         * this group.
-                         *
-                         * This allow the error to be cached, and allows the rest of the
-                         * requests made by this DataLoader to succeed.
-                         *
-                         * @see https://github.com/graphql/dataloader#caching-errors
-                         */
-                        if (response instanceof Error) {
-                            response = requestIDs.map((requestId) => {
-                                /**
-                                 * Since we're returning an error object and not the
-                                 * expected return type from the resource, this element
-                                 * would be unsortable, since it wouldn't have the
-                                 * "reorderResultsByKey" attribute.
-                                 *
-                                 * Let's add it to the error object, as "reorderResultsByValue".
-                                 *
-                                 * (If we didn't specify that this resource needs
-                                 * sorting, then this will be "null" and won't be used.)
-                                 */
-                                const reorderResultsByValue = null;
-
-                                // Tell flow that "response" is actually an error object.
-                                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                                invariant(response instanceof Error, 'expected response to be an error');
-
-                                return new CaughtResourceError(
-                                    `[dataloader-codegen :: getVehicles] Caught error during call to resource. Error: ${response.stack}`,
-                                    response,
-                                    reorderResultsByValue,
-                                );
-                            });
-                        }
-
-                        return response;
-                    }),
-                );
-
-                // Split the results back up into the order that they were requested
-                return unPartitionResults(requestGroups, groupedResults);
-            },
-            {
-                ...cacheKeyOptions,
-            },
-        ),
-        getFilms: new DataLoader<
-            {|
-                ...$Diff<
-                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
-                    {
-                        film_ids: $PropertyType<
-                            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
-                            'film_ids',
-                        >,
-                    },
-                >,
-                ...{|
-                    film_id: $Call<
-                        ExtractArg,
-                        [
-                            $PropertyType<
-                                $PropertyType<
-                                    $Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>,
-                                    'film_ids',
-                                >,
-                                'has',
-                            >,
-                        ],
-                    >,
-                |},
-            |},
-            $ElementType<
-                $Call<
-                    ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getFilms'>]>]>,
-                    $PropertyType<ResourcesType, 'getFilms'>,
-                >,
-                0,
-            >,
-            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-            string,
-        >(
-            /**
-             * ===============================================================
-             * Generated DataLoader: getFilms
-             * ===============================================================
-             *
-             * Resource Config:
-             *
-             * ```json
-             * {
-             *   "docsLink": "https://swapi.dev/documentation#films",
-             *   "isBatchResource": true,
-             *   "batchKey": "film_ids",
-             *   "newKey": "film_id",
-             *   "isBatchKeyASet": true
-             * }
-             * ```
-             */
-            async (keys) => {
-                invariant(
-                    typeof resources.getFilms === 'function',
+                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                if (!(_response instanceof Error)) {
+                  _response = new Error(
                     [
-                        '[dataloader-codegen :: getFilms] resources.getFilms is not a function.',
-                        'Did you pass in an instance of getFilms to "getLoaders"?',
-                    ].join(' '),
+                      `[dataloader-codegen :: getVehicles] Caught an error, but errorHandler did not return an Error object.`,
+                      `Instead, got ${typeof _response}: ${util.inspect(
+                        _response
+                      )}`
+                    ].join(" ")
+                  );
+                }
+              }
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.after
+              ) {
+                _response = await options.resourceMiddleware.after(
+                  ["getVehicles"],
+                  _response
                 );
+              }
+
+              return _response;
+            })(resourceArgs);
+
+            if (!(response instanceof Error)) {
+            }
+
+            if (!(response instanceof Error)) {
+              if (!Array.isArray(response)) {
+                response = new Error(
+                  [
+                    "[dataloader-codegen :: getVehicles]",
+                    "Expected response to be an array!"
+                  ].join(" ")
+                );
+              }
+            }
+
+            if (!(response instanceof Error)) {
+              /**
+               * Check to see the resource contains the same number
+               * of items that we requested. If not, since there's
+               * no "reorderResultsByKey" specified for this resource,
+               * we don't know _which_ key's response is missing. Therefore
+               * it's unsafe to return the response array back.
+               */
+              if (response.length !== requests.length) {
+                /**
+                 * We must return errors for all keys in this group :(
+                 */
+                response = new BatchItemNotFoundError(
+                  [
+                    `[dataloader-codegen :: getVehicles] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
+                  ].join(" ")
+                );
+
+                // Tell flow that BatchItemNotFoundError extends Error.
+                // It's an issue with flowgen package, but not an issue with Flow.
+                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                invariant(
+                  response instanceof Error,
+                  "expected BatchItemNotFoundError to be an Error"
+                );
+              }
+            }
+
+            /**
+             * If the resource returns an Error, we'll want to copy and
+             * return that error as the return value for every request in
+             * this group.
+             *
+             * This allow the error to be cached, and allows the rest of the
+             * requests made by this DataLoader to succeed.
+             *
+             * @see https://github.com/graphql/dataloader#caching-errors
+             */
+            if (response instanceof Error) {
+              response = requestIDs.map(requestId => {
+                /**
+                 * Since we're returning an error object and not the
+                 * expected return type from the resource, this element
+                 * would be unsortable, since it wouldn't have the
+                 * "reorderResultsByKey" attribute.
+                 *
+                 * Let's add it to the error object, as "reorderResultsByValue".
+                 *
+                 * (If we didn't specify that this resource needs
+                 * sorting, then this will be "null" and won't be used.)
+                 */
+                const reorderResultsByValue = null;
+
+                // Tell flow that "response" is actually an error object.
+                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                invariant(
+                  response instanceof Error,
+                  "expected response to be an error"
+                );
+
+                return new CaughtResourceError(
+                  `[dataloader-codegen :: getVehicles] Caught error during call to resource. Error: ${response.stack}`,
+                  response,
+                  reorderResultsByValue
+                );
+              });
+            }
+
+            return response;
+          })
+        );
+
+        // Split the results back up into the order that they were requested
+        return unPartitionResults(requestGroups, groupedResults);
+      },
+      {
+        ...cacheKeyOptions
+      }
+    ),
+    getFilms: new DataLoader<
+      {|
+        ...$Diff<
+          $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
+          {
+            film_ids: $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
+              "film_ids"
+            >
+          }
+        >,
+        ...{|
+          film_id: $Call<
+            ExtractArg,
+            [
+              $PropertyType<
+                $PropertyType<
+                  $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>,
+                  "film_ids"
+                >,
+                "has"
+              >
+            ]
+          >
+        |}
+      |},
+      $ElementType<
+        $Call<
+          ExtractPromisedReturnValue<
+            [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilms">]>]
+          >,
+          $PropertyType<ResourcesType, "getFilms">
+        >,
+        0
+      >,
+      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+      string
+    >(
+      /**
+       * ===============================================================
+       * Generated DataLoader: getFilms
+       * ===============================================================
+       *
+       * Resource Config:
+       *
+       * ```json
+       * {
+       *   "docsLink": "https://swapi.dev/documentation#films",
+       *   "isBatchResource": true,
+       *   "batchKey": "film_ids",
+       *   "newKey": "film_id",
+       *   "isBatchKeyASet": true
+       * }
+       * ```
+       */
+      async keys => {
+        invariant(
+          typeof resources.getFilms === "function",
+          [
+            "[dataloader-codegen :: getFilms] resources.getFilms is not a function.",
+            'Did you pass in an instance of getFilms to "getLoaders"?'
+          ].join(" ")
+        );
+
+        /**
+         * Chunk up the "keys" array to create a set of "request groups".
+         *
+         * We're about to hit a batch resource. In addition to the batch
+         * key, the resource may take other arguments too. When batching
+         * up requests, we'll want to look out for where those other
+         * arguments differ, and send multiple requests so we don't get
+         * back the wrong info.
+         *
+         * In other words, we'll potentially want to send _multiple_
+         * requests to the underlying resource batch method in this
+         * dataloader body.
+         *
+         * ~~~ Why? ~~~
+         *
+         * Consider what happens when we get called with arguments where
+         * the non-batch keys differ.
+         *
+         * Example:
+         *
+         * ```js
+         * loaders.foo.load({ foo_id: 2, include_private_data: true });
+         * loaders.foo.load({ foo_id: 3, include_private_data: false });
+         * loaders.foo.load({ foo_id: 4, include_private_data: false });
+         * ```
+         *
+         * If we collected everything up and tried to send the one
+         * request to the resource as a batch request, how do we know
+         * what the value for "include_private_data" should be? We're
+         * going to have to group these up up and send two requests to
+         * the resource to make sure we're requesting the right stuff.
+         *
+         * e.g. We'd need to make the following set of underlying resource
+         * calls:
+         *
+         * ```js
+         * foo({ foo_ids: [ 2 ], include_private_data: true });
+         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+         * ```
+         *
+         * ~~~ tl;dr ~~~
+         *
+         * When we have calls to .load with differing non batch key args,
+         * we'll need to send multiple requests to the underlying
+         * resource to make sure we get the right results back.
+         *
+         * Let's create the request groups, where each element in the
+         * group refers to a position in "keys" (i.e. a call to .load)
+         *
+         * Example:
+         *
+         * ```js
+         * partitionItems([
+         *   { bar_id: 7, include_extra_info: true },
+         *   { bar_id: 8, include_extra_info: false },
+         *   { bar_id: 9, include_extra_info: true },
+         * ], 'bar_id')
+         * ```
+         *
+         * Returns:
+         * `[ [ 0, 2 ], [ 1 ] ]`
+         *
+         * We'll refer to each element in the group as a "request ID".
+         */
+        const requestGroups = partitionItems("film_id", keys);
+
+        // Map the request groups to a list of Promises - one for each request
+        const groupedResults = await Promise.all(
+          requestGroups.map(async requestIDs => {
+            /**
+             * Select a set of elements in "keys", where all non-batch
+             * keys should be identical.
+             *
+             * We're going to smoosh all these together into one payload to
+             * send to the resource as a batch request!
+             */
+            const requests = requestIDs.map(id => keys[id]);
+
+            // For now, we assume that the dataloader key should be the first argument to the resource
+            // @see https://github.com/Yelp/dataloader-codegen/issues/56
+            const resourceArgs = [
+              {
+                ..._.omit(requests[0], "film_id"),
+                ["film_ids"]: requests.map(k => k["film_id"])
+              }
+            ];
+
+            let response = await (async _resourceArgs => {
+              // Make a re-assignable variable so flow/eslint doesn't complain
+              let __resourceArgs = _resourceArgs;
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.before
+              ) {
+                __resourceArgs = await options.resourceMiddleware.before(
+                  ["getFilms"],
+                  __resourceArgs
+                );
+              }
+
+              let _response;
+              try {
+                // Finally, call the resource!
+                _response = await resources.getFilms(...__resourceArgs);
+              } catch (error) {
+                const errorHandler =
+                  options && typeof options.errorHandler === "function"
+                    ? options.errorHandler
+                    : defaultErrorHandler;
 
                 /**
-                 * Chunk up the "keys" array to create a set of "request groups".
+                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
                  *
-                 * We're about to hit a batch resource. In addition to the batch
-                 * key, the resource may take other arguments too. When batching
-                 * up requests, we'll want to look out for where those other
-                 * arguments differ, and send multiple requests so we don't get
-                 * back the wrong info.
-                 *
-                 * In other words, we'll potentially want to send _multiple_
-                 * requests to the underlying resource batch method in this
-                 * dataloader body.
-                 *
-                 * ~~~ Why? ~~~
-                 *
-                 * Consider what happens when we get called with arguments where
-                 * the non-batch keys differ.
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * loaders.foo.load({ foo_id: 2, include_private_data: true });
-                 * loaders.foo.load({ foo_id: 3, include_private_data: false });
-                 * loaders.foo.load({ foo_id: 4, include_private_data: false });
-                 * ```
-                 *
-                 * If we collected everything up and tried to send the one
-                 * request to the resource as a batch request, how do we know
-                 * what the value for "include_private_data" should be? We're
-                 * going to have to group these up up and send two requests to
-                 * the resource to make sure we're requesting the right stuff.
-                 *
-                 * e.g. We'd need to make the following set of underlying resource
-                 * calls:
-                 *
-                 * ```js
-                 * foo({ foo_ids: [ 2 ], include_private_data: true });
-                 * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
-                 * ```
-                 *
-                 * ~~~ tl;dr ~~~
-                 *
-                 * When we have calls to .load with differing non batch key args,
-                 * we'll need to send multiple requests to the underlying
-                 * resource to make sure we get the right results back.
-                 *
-                 * Let's create the request groups, where each element in the
-                 * group refers to a position in "keys" (i.e. a call to .load)
-                 *
-                 * Example:
-                 *
-                 * ```js
-                 * partitionItems([
-                 *   { bar_id: 7, include_extra_info: true },
-                 *   { bar_id: 8, include_extra_info: false },
-                 *   { bar_id: 9, include_extra_info: true },
-                 * ], 'bar_id')
-                 * ```
-                 *
-                 * Returns:
-                 * `[ [ 0, 2 ], [ 1 ] ]`
-                 *
-                 * We'll refer to each element in the group as a "request ID".
+                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
                  */
-                const requestGroups = partitionItems('film_id', keys);
+                _response = await errorHandler(["getFilms"], error);
 
-                // Map the request groups to a list of Promises - one for each request
-                const groupedResults = await Promise.all(
-                    requestGroups.map(async (requestIDs) => {
-                        /**
-                         * Select a set of elements in "keys", where all non-batch
-                         * keys should be identical.
-                         *
-                         * We're going to smoosh all these together into one payload to
-                         * send to the resource as a batch request!
-                         */
-                        const requests = requestIDs.map((id) => keys[id]);
+                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                if (!(_response instanceof Error)) {
+                  _response = new Error(
+                    [
+                      `[dataloader-codegen :: getFilms] Caught an error, but errorHandler did not return an Error object.`,
+                      `Instead, got ${typeof _response}: ${util.inspect(
+                        _response
+                      )}`
+                    ].join(" ")
+                  );
+                }
+              }
 
-                        // For now, we assume that the dataloader key should be the first argument to the resource
-                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
-                        const resourceArgs = [
-                            {
-                                ..._.omit(requests[0], 'film_id'),
-                                ['film_ids']: requests.map((k) => k['film_id']),
-                            },
-                        ];
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.after
+              ) {
+                _response = await options.resourceMiddleware.after(
+                  ["getFilms"],
+                  _response
+                );
+              }
 
-                        let response = await (async (_resourceArgs) => {
-                            // Make a re-assignable variable so flow/eslint doesn't complain
-                            let __resourceArgs = _resourceArgs;
+              return _response;
+            })(resourceArgs);
 
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
-                                __resourceArgs = await options.resourceMiddleware.before(['getFilms'], __resourceArgs);
-                            }
+            if (!(response instanceof Error)) {
+            }
 
-                            let _response;
-                            try {
-                                // Finally, call the resource!
-                                _response = await resources.getFilms(...__resourceArgs);
-                            } catch (error) {
-                                const errorHandler =
-                                    options && typeof options.errorHandler === 'function'
-                                        ? options.errorHandler
-                                        : defaultErrorHandler;
+            if (!(response instanceof Error)) {
+              if (!Array.isArray(response)) {
+                response = new Error(
+                  [
+                    "[dataloader-codegen :: getFilms]",
+                    "Expected response to be an array!"
+                  ].join(" ")
+                );
+              }
+            }
 
-                                /**
-                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                                 *
-                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                                 */
-                                _response = await errorHandler(['getFilms'], error);
-
-                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                                if (!(_response instanceof Error)) {
-                                    _response = new Error(
-                                        [
-                                            `[dataloader-codegen :: getFilms] Caught an error, but errorHandler did not return an Error object.`,
-                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
-                                        ].join(' '),
-                                    );
-                                }
-                            }
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
-                                _response = await options.resourceMiddleware.after(['getFilms'], _response);
-                            }
-
-                            return _response;
-                        })(resourceArgs);
-
-                        if (!(response instanceof Error)) {
-                        }
-
-                        if (!(response instanceof Error)) {
-                            if (!Array.isArray(response)) {
-                                response = new Error(
-                                    ['[dataloader-codegen :: getFilms]', 'Expected response to be an array!'].join(' '),
-                                );
-                            }
-                        }
-
-                        if (!(response instanceof Error)) {
-                            /**
-                             * Check to see the resource contains the same number
-                             * of items that we requested. If not, since there's
-                             * no "reorderResultsByKey" specified for this resource,
-                             * we don't know _which_ key's response is missing. Therefore
-                             * it's unsafe to return the response array back.
-                             */
-                            if (response.length !== requests.length) {
-                                /**
-                                 * We must return errors for all keys in this group :(
-                                 */
-                                response = new BatchItemNotFoundError(
-                                    [
-                                        `[dataloader-codegen :: getFilms] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
-                                        'Add reorderResultsByKey to the config for this resource to be able to handle a partial response.',
-                                    ].join(' '),
-                                );
-
-                                // Tell flow that BatchItemNotFoundError extends Error.
-                                // It's an issue with flowgen package, but not an issue with Flow.
-                                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
-                                invariant(response instanceof Error, 'expected BatchItemNotFoundError to be an Error');
-                            }
-                        }
-
-                        /**
-                         * If the resource returns an Error, we'll want to copy and
-                         * return that error as the return value for every request in
-                         * this group.
-                         *
-                         * This allow the error to be cached, and allows the rest of the
-                         * requests made by this DataLoader to succeed.
-                         *
-                         * @see https://github.com/graphql/dataloader#caching-errors
-                         */
-                        if (response instanceof Error) {
-                            response = requestIDs.map((requestId) => {
-                                /**
-                                 * Since we're returning an error object and not the
-                                 * expected return type from the resource, this element
-                                 * would be unsortable, since it wouldn't have the
-                                 * "reorderResultsByKey" attribute.
-                                 *
-                                 * Let's add it to the error object, as "reorderResultsByValue".
-                                 *
-                                 * (If we didn't specify that this resource needs
-                                 * sorting, then this will be "null" and won't be used.)
-                                 */
-                                const reorderResultsByValue = null;
-
-                                // Tell flow that "response" is actually an error object.
-                                // (This is so we can pass it as 'cause' to CaughtResourceError)
-                                invariant(response instanceof Error, 'expected response to be an error');
-
-                                return new CaughtResourceError(
-                                    `[dataloader-codegen :: getFilms] Caught error during call to resource. Error: ${response.stack}`,
-                                    response,
-                                    reorderResultsByValue,
-                                );
-                            });
-                        }
-
-                        return response;
-                    }),
+            if (!(response instanceof Error)) {
+              /**
+               * Check to see the resource contains the same number
+               * of items that we requested. If not, since there's
+               * no "reorderResultsByKey" specified for this resource,
+               * we don't know _which_ key's response is missing. Therefore
+               * it's unsafe to return the response array back.
+               */
+              if (response.length !== requests.length) {
+                /**
+                 * We must return errors for all keys in this group :(
+                 */
+                response = new BatchItemNotFoundError(
+                  [
+                    `[dataloader-codegen :: getFilms] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
+                  ].join(" ")
                 );
 
-                // Split the results back up into the order that they were requested
-                return unPartitionResults(requestGroups, groupedResults);
-            },
-            {
-                ...cacheKeyOptions,
-            },
-        ),
-        getRoot: new DataLoader<
-            $Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>,
-            $Call<
-                ExtractPromisedReturnValue<[$Call<ExtractArg, [$PropertyType<ResourcesType, 'getRoot'>]>]>,
-                $PropertyType<ResourcesType, 'getRoot'>,
-            >,
-            // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
-            string,
-        >(
+                // Tell flow that BatchItemNotFoundError extends Error.
+                // It's an issue with flowgen package, but not an issue with Flow.
+                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                invariant(
+                  response instanceof Error,
+                  "expected BatchItemNotFoundError to be an Error"
+                );
+              }
+            }
+
             /**
-             * ===============================================================
-             * Generated DataLoader: getRoot
-             * ===============================================================
+             * If the resource returns an Error, we'll want to copy and
+             * return that error as the return value for every request in
+             * this group.
              *
-             * Resource Config:
+             * This allow the error to be cached, and allows the rest of the
+             * requests made by this DataLoader to succeed.
              *
-             * ```json
-             * {
-             *   "docsLink": "https://swapi.dev/documentation#root",
-             *   "isBatchResource": false
-             * }
-             * ```
+             * @see https://github.com/graphql/dataloader#caching-errors
              */
-            async (keys) => {
-                const responses = await Promise.all(
-                    keys.map(async (key) => {
-                        invariant(
-                            typeof resources.getRoot === 'function',
-                            [
-                                '[dataloader-codegen :: getRoot] resources.getRoot is not a function.',
-                                'Did you pass in an instance of getRoot to "getLoaders"?',
-                            ].join(' '),
-                        );
+            if (response instanceof Error) {
+              response = requestIDs.map(requestId => {
+                /**
+                 * Since we're returning an error object and not the
+                 * expected return type from the resource, this element
+                 * would be unsortable, since it wouldn't have the
+                 * "reorderResultsByKey" attribute.
+                 *
+                 * Let's add it to the error object, as "reorderResultsByValue".
+                 *
+                 * (If we didn't specify that this resource needs
+                 * sorting, then this will be "null" and won't be used.)
+                 */
+                const reorderResultsByValue = null;
 
-                        // For now, we assume that the dataloader key should be the first argument to the resource
-                        // @see https://github.com/Yelp/dataloader-codegen/issues/56
-                        const resourceArgs = [key];
-
-                        return await (async (_resourceArgs) => {
-                            // Make a re-assignable variable so flow/eslint doesn't complain
-                            let __resourceArgs = _resourceArgs;
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.before) {
-                                __resourceArgs = await options.resourceMiddleware.before(['getRoot'], __resourceArgs);
-                            }
-
-                            let _response;
-                            try {
-                                // Finally, call the resource!
-                                _response = await resources.getRoot(...__resourceArgs);
-                            } catch (error) {
-                                const errorHandler =
-                                    options && typeof options.errorHandler === 'function'
-                                        ? options.errorHandler
-                                        : defaultErrorHandler;
-
-                                /**
-                                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
-                                 *
-                                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
-                                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
-                                 */
-                                _response = await errorHandler(['getRoot'], error);
-
-                                // Check that errorHandler actually returned an Error object, and turn it into one if not.
-                                if (!(_response instanceof Error)) {
-                                    _response = new Error(
-                                        [
-                                            `[dataloader-codegen :: getRoot] Caught an error, but errorHandler did not return an Error object.`,
-                                            `Instead, got ${typeof _response}: ${util.inspect(_response)}`,
-                                        ].join(' '),
-                                    );
-                                }
-                            }
-
-                            if (options && options.resourceMiddleware && options.resourceMiddleware.after) {
-                                _response = await options.resourceMiddleware.after(['getRoot'], _response);
-                            }
-
-                            return _response;
-                        })(resourceArgs);
-                    }),
+                // Tell flow that "response" is actually an error object.
+                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                invariant(
+                  response instanceof Error,
+                  "expected response to be an error"
                 );
 
-                return responses;
-            },
-            {
-                ...cacheKeyOptions,
-            },
-        ),
-    });
+                return new CaughtResourceError(
+                  `[dataloader-codegen :: getFilms] Caught error during call to resource. Error: ${response.stack}`,
+                  response,
+                  reorderResultsByValue
+                );
+              });
+            }
+
+            return response;
+          })
+        );
+
+        // Split the results back up into the order that they were requested
+        return unPartitionResults(requestGroups, groupedResults);
+      },
+      {
+        ...cacheKeyOptions
+      }
+    ),
+    getFilmsV2: new DataLoader<
+      {|
+        ...$Diff<
+          $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
+          {
+            film_ids: $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
+              "film_ids"
+            >
+          }
+        >,
+        ...{|
+          film_id: $ElementType<
+            $PropertyType<
+              $Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>,
+              "film_ids"
+            >,
+            0
+          >
+        |}
+      |},
+      $ElementType<
+        $PropertyType<
+          $Call<
+            ExtractPromisedReturnValue<
+              [$Call<ExtractArg, [$PropertyType<ResourcesType, "getFilmsV2">]>]
+            >,
+            $PropertyType<ResourcesType, "getFilmsV2">
+          >,
+          "properties"
+        >,
+        0
+      >,
+      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+      string
+    >(
+      /**
+       * ===============================================================
+       * Generated DataLoader: getFilmsV2
+       * ===============================================================
+       *
+       * Resource Config:
+       *
+       * ```json
+       * {
+       *   "docsLink": "https://swapi.dev/documentation#films",
+       *   "isBatchResource": true,
+       *   "batchKey": "film_ids",
+       *   "newKey": "film_id",
+       *   "nestedPath": "properties"
+       * }
+       * ```
+       */
+      async keys => {
+        invariant(
+          typeof resources.getFilmsV2 === "function",
+          [
+            "[dataloader-codegen :: getFilmsV2] resources.getFilmsV2 is not a function.",
+            'Did you pass in an instance of getFilmsV2 to "getLoaders"?'
+          ].join(" ")
+        );
+
+        /**
+         * Chunk up the "keys" array to create a set of "request groups".
+         *
+         * We're about to hit a batch resource. In addition to the batch
+         * key, the resource may take other arguments too. When batching
+         * up requests, we'll want to look out for where those other
+         * arguments differ, and send multiple requests so we don't get
+         * back the wrong info.
+         *
+         * In other words, we'll potentially want to send _multiple_
+         * requests to the underlying resource batch method in this
+         * dataloader body.
+         *
+         * ~~~ Why? ~~~
+         *
+         * Consider what happens when we get called with arguments where
+         * the non-batch keys differ.
+         *
+         * Example:
+         *
+         * ```js
+         * loaders.foo.load({ foo_id: 2, include_private_data: true });
+         * loaders.foo.load({ foo_id: 3, include_private_data: false });
+         * loaders.foo.load({ foo_id: 4, include_private_data: false });
+         * ```
+         *
+         * If we collected everything up and tried to send the one
+         * request to the resource as a batch request, how do we know
+         * what the value for "include_private_data" should be? We're
+         * going to have to group these up up and send two requests to
+         * the resource to make sure we're requesting the right stuff.
+         *
+         * e.g. We'd need to make the following set of underlying resource
+         * calls:
+         *
+         * ```js
+         * foo({ foo_ids: [ 2 ], include_private_data: true });
+         * foo({ foo_ids: [ 3, 4 ], include_private_data: false });
+         * ```
+         *
+         * ~~~ tl;dr ~~~
+         *
+         * When we have calls to .load with differing non batch key args,
+         * we'll need to send multiple requests to the underlying
+         * resource to make sure we get the right results back.
+         *
+         * Let's create the request groups, where each element in the
+         * group refers to a position in "keys" (i.e. a call to .load)
+         *
+         * Example:
+         *
+         * ```js
+         * partitionItems([
+         *   { bar_id: 7, include_extra_info: true },
+         *   { bar_id: 8, include_extra_info: false },
+         *   { bar_id: 9, include_extra_info: true },
+         * ], 'bar_id')
+         * ```
+         *
+         * Returns:
+         * `[ [ 0, 2 ], [ 1 ] ]`
+         *
+         * We'll refer to each element in the group as a "request ID".
+         */
+        const requestGroups = partitionItems("film_id", keys);
+
+        // Map the request groups to a list of Promises - one for each request
+        const groupedResults = await Promise.all(
+          requestGroups.map(async requestIDs => {
+            /**
+             * Select a set of elements in "keys", where all non-batch
+             * keys should be identical.
+             *
+             * We're going to smoosh all these together into one payload to
+             * send to the resource as a batch request!
+             */
+            const requests = requestIDs.map(id => keys[id]);
+
+            // For now, we assume that the dataloader key should be the first argument to the resource
+            // @see https://github.com/Yelp/dataloader-codegen/issues/56
+            const resourceArgs = [
+              {
+                ..._.omit(requests[0], "film_id"),
+                ["film_ids"]: requests.map(k => k["film_id"])
+              }
+            ];
+
+            let response = await (async _resourceArgs => {
+              // Make a re-assignable variable so flow/eslint doesn't complain
+              let __resourceArgs = _resourceArgs;
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.before
+              ) {
+                __resourceArgs = await options.resourceMiddleware.before(
+                  ["getFilmsV2"],
+                  __resourceArgs
+                );
+              }
+
+              let _response;
+              try {
+                // Finally, call the resource!
+                _response = await resources.getFilmsV2(...__resourceArgs);
+              } catch (error) {
+                const errorHandler =
+                  options && typeof options.errorHandler === "function"
+                    ? options.errorHandler
+                    : defaultErrorHandler;
+
+                /**
+                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                 *
+                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                 */
+                _response = await errorHandler(["getFilmsV2"], error);
+
+                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                if (!(_response instanceof Error)) {
+                  _response = new Error(
+                    [
+                      `[dataloader-codegen :: getFilmsV2] Caught an error, but errorHandler did not return an Error object.`,
+                      `Instead, got ${typeof _response}: ${util.inspect(
+                        _response
+                      )}`
+                    ].join(" ")
+                  );
+                }
+              }
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.after
+              ) {
+                _response = await options.resourceMiddleware.after(
+                  ["getFilmsV2"],
+                  _response
+                );
+              }
+
+              return _response;
+            })(resourceArgs);
+
+            if (!(response instanceof Error)) {
+              /**
+               * Un-nest the actual data from the resource return value.
+               *
+               * e.g.
+               * ```js
+               * {
+               *   foos: [
+               *     { id: 1, value: 'hello' },
+               *     { id: 2, value: 'world' },
+               *   ]
+               * }
+               * ```
+               *
+               * Becomes
+               *
+               * ```js
+               * [
+               *   { id: 1, value: 'hello' },
+               *   { id: 2, value: 'world' },
+               * ]
+               * ```
+               */
+              response = _.get(
+                response,
+                "properties",
+                new Error(
+                  [
+                    "[dataloader-codegen :: getFilmsV2]",
+                    "Tried to un-nest the response from the resource, but",
+                    ".get(response, 'properties')",
+                    "was empty!"
+                  ].join(" ")
+                )
+              );
+            }
+
+            if (!(response instanceof Error)) {
+              if (!Array.isArray(response)) {
+                response = new Error(
+                  [
+                    "[dataloader-codegen :: getFilmsV2]",
+                    "Expected response to be an array!"
+                  ].join(" ")
+                );
+              }
+            }
+
+            if (!(response instanceof Error)) {
+              /**
+               * Check to see the resource contains the same number
+               * of items that we requested. If not, since there's
+               * no "reorderResultsByKey" specified for this resource,
+               * we don't know _which_ key's response is missing. Therefore
+               * it's unsafe to return the response array back.
+               */
+              if (response.length !== requests.length) {
+                /**
+                 * We must return errors for all keys in this group :(
+                 */
+                response = new BatchItemNotFoundError(
+                  [
+                    `[dataloader-codegen :: getFilmsV2] Resource returned ${response.length} items, but we requested ${requests.length} items.`,
+                    "Add reorderResultsByKey to the config for this resource to be able to handle a partial response."
+                  ].join(" ")
+                );
+
+                // Tell flow that BatchItemNotFoundError extends Error.
+                // It's an issue with flowgen package, but not an issue with Flow.
+                // @see https://github.com/Yelp/dataloader-codegen/pull/35#discussion_r394777533
+                invariant(
+                  response instanceof Error,
+                  "expected BatchItemNotFoundError to be an Error"
+                );
+              }
+            }
+
+            /**
+             * If the resource returns an Error, we'll want to copy and
+             * return that error as the return value for every request in
+             * this group.
+             *
+             * This allow the error to be cached, and allows the rest of the
+             * requests made by this DataLoader to succeed.
+             *
+             * @see https://github.com/graphql/dataloader#caching-errors
+             */
+            if (response instanceof Error) {
+              response = requestIDs.map(requestId => {
+                /**
+                 * Since we're returning an error object and not the
+                 * expected return type from the resource, this element
+                 * would be unsortable, since it wouldn't have the
+                 * "reorderResultsByKey" attribute.
+                 *
+                 * Let's add it to the error object, as "reorderResultsByValue".
+                 *
+                 * (If we didn't specify that this resource needs
+                 * sorting, then this will be "null" and won't be used.)
+                 */
+                const reorderResultsByValue = null;
+
+                // Tell flow that "response" is actually an error object.
+                // (This is so we can pass it as 'cause' to CaughtResourceError)
+                invariant(
+                  response instanceof Error,
+                  "expected response to be an error"
+                );
+
+                return new CaughtResourceError(
+                  `[dataloader-codegen :: getFilmsV2] Caught error during call to resource. Error: ${response.stack}`,
+                  response,
+                  reorderResultsByValue
+                );
+              });
+            }
+
+            return response;
+          })
+        );
+
+        // Split the results back up into the order that they were requested
+        return unPartitionResults(requestGroups, groupedResults);
+      },
+      {
+        ...cacheKeyOptions
+      }
+    ),
+    getRoot: new DataLoader<
+      $Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>,
+      $Call<
+        ExtractPromisedReturnValue<
+          [$Call<ExtractArg, [$PropertyType<ResourcesType, "getRoot">]>]
+        >,
+        $PropertyType<ResourcesType, "getRoot">
+      >,
+      // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
+      string
+    >(
+      /**
+       * ===============================================================
+       * Generated DataLoader: getRoot
+       * ===============================================================
+       *
+       * Resource Config:
+       *
+       * ```json
+       * {
+       *   "docsLink": "https://swapi.dev/documentation#root",
+       *   "isBatchResource": false
+       * }
+       * ```
+       */
+      async keys => {
+        const responses = await Promise.all(
+          keys.map(async key => {
+            invariant(
+              typeof resources.getRoot === "function",
+              [
+                "[dataloader-codegen :: getRoot] resources.getRoot is not a function.",
+                'Did you pass in an instance of getRoot to "getLoaders"?'
+              ].join(" ")
+            );
+
+            // For now, we assume that the dataloader key should be the first argument to the resource
+            // @see https://github.com/Yelp/dataloader-codegen/issues/56
+            const resourceArgs = [key];
+
+            return await (async _resourceArgs => {
+              // Make a re-assignable variable so flow/eslint doesn't complain
+              let __resourceArgs = _resourceArgs;
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.before
+              ) {
+                __resourceArgs = await options.resourceMiddleware.before(
+                  ["getRoot"],
+                  __resourceArgs
+                );
+              }
+
+              let _response;
+              try {
+                // Finally, call the resource!
+                _response = await resources.getRoot(...__resourceArgs);
+              } catch (error) {
+                const errorHandler =
+                  options && typeof options.errorHandler === "function"
+                    ? options.errorHandler
+                    : defaultErrorHandler;
+
+                /**
+                 * Apply some error handling to catch and handle all errors/rejected promises. errorHandler must return an Error object.
+                 *
+                 * If we let errors here go unhandled here, it will bubble up and DataLoader will return an error for all
+                 * keys requested. We can do slightly better by returning the error object for just the keys in this batch request.
+                 */
+                _response = await errorHandler(["getRoot"], error);
+
+                // Check that errorHandler actually returned an Error object, and turn it into one if not.
+                if (!(_response instanceof Error)) {
+                  _response = new Error(
+                    [
+                      `[dataloader-codegen :: getRoot] Caught an error, but errorHandler did not return an Error object.`,
+                      `Instead, got ${typeof _response}: ${util.inspect(
+                        _response
+                      )}`
+                    ].join(" ")
+                  );
+                }
+              }
+
+              if (
+                options &&
+                options.resourceMiddleware &&
+                options.resourceMiddleware.after
+              ) {
+                _response = await options.resourceMiddleware.after(
+                  ["getRoot"],
+                  _response
+                );
+              }
+
+              return _response;
+            })(resourceArgs);
+          })
+        );
+
+        return responses;
+      },
+      {
+        ...cacheKeyOptions
+      }
+    )
+  });
 }

--- a/examples/swapi/swapi-server.js
+++ b/examples/swapi/swapi-server.js
@@ -148,7 +148,7 @@ const createSWAPIServer = () => {
 
         async director() {
             const response = await swapiLoaders.getFilmsV2.load({ film_id: this.id, properties: ['director'] });
-        
+
             if (response instanceof Error) {
                 return response;
             }
@@ -158,7 +158,7 @@ const createSWAPIServer = () => {
             }
         }
     }
-    
+
     const root = {
         planet: ({ id }) => {
             return new PlanetModel(id);

--- a/examples/swapi/swapi-server.js
+++ b/examples/swapi/swapi-server.js
@@ -23,6 +23,7 @@ const createSWAPIServer = () => {
         type Query {
             planet(id: Int): Planet
             film(id: Int): Film
+            filmv2(id: Int): Film
         }
     `);
 
@@ -114,12 +115,59 @@ const createSWAPIServer = () => {
         }
     }
 
+    class FilmModelV2 {
+        id: number;
+
+        constructor(id: number) {
+            this.id = id;
+        }
+
+        async title() {
+            const response = await swapiLoaders.getFilmsV2.load({ film_id: this.id, properties: ['title'] });
+
+            if (response instanceof Error) {
+                return response;
+            }
+
+            if (response) {
+                return response.title;
+            }
+        }
+
+        async episodeNumber() {
+            const response = await swapiLoaders.getFilmsV2.load({ film_id: this.id, properties: ['episode_id'] });
+
+            if (response instanceof Error) {
+                return response;
+            }
+
+            if (response) {
+                return response.episode_id;
+            }
+        }
+
+        async director() {
+            const response = await swapiLoaders.getFilmsV2.load({ film_id: this.id, properties: ['director'] });
+        
+            if (response instanceof Error) {
+                return response;
+            }
+
+            if (response) {
+                return response.director;
+            }
+        }
+    }
+    
     const root = {
         planet: ({ id }) => {
             return new PlanetModel(id);
         },
         film: ({ id }) => {
             return new FilmModel(id);
+        },
+        filmv2: ({ id }) => {
+            return new FilmModelV2(id);
         },
     };
 
@@ -151,6 +199,11 @@ runQuery(/* GraphQL */ `
             director
         }
         theBest: film(id: 4) {
+            title
+            episodeNumber
+            director
+        }
+        theBestV2: filmv2(id: 4) {
             title
             episodeNumber
             director

--- a/examples/swapi/swapi.dataloader-config.yaml
+++ b/examples/swapi/swapi.dataloader-config.yaml
@@ -28,6 +28,12 @@ resources:
         batchKey: film_ids
         newKey: film_id
         isBatchKeyASet: true
+    getFilmsV2:
+        docsLink: https://swapi.dev/documentation#films
+        isBatchResource: true
+        batchKey: film_ids
+        newKey: film_id
+        nestedPath: properties
     getRoot:
         docsLink: https://swapi.dev/documentation#root
         isBatchResource: false

--- a/examples/swapi/swapi.js
+++ b/examples/swapi/swapi.js
@@ -60,6 +60,16 @@ export type SWAPI_Film = $ReadOnly<{|
     edited: string,
 |}>;
 
+export type SWAPI_Film_V2 = $ReadOnly<{|
+    properties: $ReadOnlyArray<{|
+        film_id: number,
+        title: string,
+        episode_id: number,
+        director: string,
+        producer: string,
+    |}>,
+|}>;
+
 export type SWAPI_Vehicle = $ReadOnly<{|
     name: string,
     key: string,
@@ -79,6 +89,10 @@ export type SWAPIClientlibTypes = {|
     getPeople: ({| people_ids: $ReadOnlyArray<number> |}) => Promise<$ReadOnlyArray<SWAPI_Person>>,
     getVehicles: ({| vehicle_ids: $ReadOnlyArray<number> |}) => Promise<$ReadOnlyArray<SWAPI_Vehicle>>,
     getFilms: ({| film_ids: Set<number> |}) => Promise<$ReadOnlyArray<SWAPI_Film>>,
+    getFilmsV2: ({|
+        film_ids: $ReadOnlyArray<number>,
+        properties: $ReadOnlyArray<string>,
+    |}) => Promise<SWAPI_Film_V2>,
     getRoot: ({||}) => Promise<SWAPI_Root>,
 |};
 
@@ -100,6 +114,19 @@ module.exports = function (): SWAPIClientlibTypes {
             Promise.all(
                 [...film_ids].map((id) => fetch(url.resolve(SWAPI_URL, `films/${id}`)).then((res) => res.json())),
             ),
+        getFilmsV2: ({ film_ids, properties }) => {
+            return Promise.resolve({
+                properties: [
+                    {
+                        film_id: 4,
+                        director: 'George Lucas',
+                        producer: 'Rick McCallum',
+                        episode_id: 1,
+                        title: 'The Phantom Menace',
+                    },
+                ],
+            });
+        },
         getRoot: ({}) => fetch(SWAPI_URL).then((res) => res.json()),
     };
 };

--- a/src/genTypeFlow.ts
+++ b/src/genTypeFlow.ts
@@ -91,32 +91,31 @@ export function getLoaderTypeVal(resourceConfig: ResourceConfig, resourcePath: R
             ${getResourceTypeReference(resourceConfig, resourcePath)}
         >`;
 
-    /**
-     * If the response is nested in some path, unwrap it.
-     *
-     * Example:
-     * ```js
-     * {
-     *   businesses: [
-     *     { id: 1, name: 'foo' },
-     *     { id: 2, name: 'bar' }
-     *   ]
-     * }
-     * ```
-     *
-     * Becomes:
-     * ```js
-     * [
-     *   { id: 1, name: 'foo' },
-     *   { id: 2, name: 'bar' }
-     * ]
-     * ```
-     */
-    if (resourceConfig.isBatchResource && resourceConfig.nestedPath) {
-        retVal = `$PropertyType<${retVal}, '${resourceConfig.nestedPath}'>`;
-    }
-
     if (resourceConfig.isBatchResource) {
+        /**
+         * If the response is nested in some path, unwrap it.
+         *
+         * Example:
+         * ```js
+         * {
+         *   businesses: [
+         *     { id: 1, name: 'foo' },
+         *     { id: 2, name: 'bar' }
+         *   ]
+         * }
+         * ```
+         *
+         * Becomes:
+         * ```js
+         * [
+         *   { id: 1, name: 'foo' },
+         *   { id: 2, name: 'bar' }
+         * ]
+         * ```
+         */
+        if (resourceConfig.nestedPath) {
+            retVal = `$PropertyType<${retVal}, '${resourceConfig.nestedPath}'>`;
+        }
         retVal = resourceConfig.isResponseDictionary ? `$Values<${retVal}>` : `$ElementType<${retVal}, 0>`;
     }
 

--- a/src/genTypeFlow.ts
+++ b/src/genTypeFlow.ts
@@ -91,10 +91,6 @@ export function getLoaderTypeVal(resourceConfig: ResourceConfig, resourcePath: R
             ${getResourceTypeReference(resourceConfig, resourcePath)}
         >`;
 
-    if (resourceConfig.isBatchResource) {
-        retVal = resourceConfig.isResponseDictionary ? `$Values<${retVal}>` : `$ElementType<${retVal}, 0>`;
-    }
-
     /**
      * If the response is nested in some path, unwrap it.
      *
@@ -118,6 +114,10 @@ export function getLoaderTypeVal(resourceConfig: ResourceConfig, resourcePath: R
      */
     if (resourceConfig.isBatchResource && resourceConfig.nestedPath) {
         retVal = `$PropertyType<${retVal}, '${resourceConfig.nestedPath}'>`;
+    }
+
+    if (resourceConfig.isBatchResource) {
+        retVal = resourceConfig.isResponseDictionary ? `$Values<${retVal}>` : `$ElementType<${retVal}, 0>`;
     }
 
     return retVal;


### PR DESCRIPTION
## Issue: 
codegen generate wrong flow type when I use `nestedPath`. 

dataloader-config.yaml
```
   getFilmsV2:
        docsLink: https://swapi.dev/documentation#films
        isBatchResource: true
        batchKey: film_ids
        newKey: film_id
        nestedPath: properties
```

## Status Quo
<img width="773" alt="Screen Shot 2021-06-30 at 9 41 54 AM" src="https://user-images.githubusercontent.com/11169895/124000522-84b27680-d988-11eb-8eee-4c3d9249fda3.png">

The flow type of `response` is `any`, which is wrong!

## after my change in src/genTypeFlow.ts

<img width="774" alt="Screen Shot 2021-06-30 at 9 43 22 AM" src="https://user-images.githubusercontent.com/11169895/124000613-9b58cd80-d988-11eb-90cf-9ee44ef2e921.png">
We get the correct flow type. 


## What's wrong?
If the response is nested in some path, we need to first unwrap it. Then if it's a batch resource, we do `$ElementType<${retVal}, 0>` The order of two if-else statement matters!  

## Test Done
make test passed 
Also see my swapi example ^ (screen shot above)