### PR TITLE
Forces nullable batchKeys to be non-nullable

### DIFF
--- a/__tests__/genTypeFlow.test.js
+++ b/__tests__/genTypeFlow.test.js
@@ -1,4 +1,4 @@
-import { getResourceTypeReference, getNewKeyTypeFromBatchKeySetType } from '../src/genTypeFlow';
+import { getResourceTypeReference, getNewKeyTypeFromBatchKeySetType, getLoaderTypeKey } from '../src/genTypeFlow';
 
 it('getResourceTypeReference converts a resource path to a valid reference', () => {
     expect(getResourceTypeReference(null, ['foo', 'bar', 'baz'])).toBe(
@@ -17,4 +17,31 @@ it('getNewKeyTypeFromBatchKeySetType returns a newKey type with a valid value', 
             ExtractArg,
             [$PropertyType<$PropertyType<$PropertyType<$PropertyType<$PropertyType<ResourcesType, 'foo'>, 'bar'>, 'baz'>, 'bKey'>, 'has'>]
         >`);
+});
+
+it('getLoaderTypeKey forces a nullable batchKey to be strictly non-nullable', () => {
+    expect(
+        getLoaderTypeKey(
+            {
+                isBatchResource: true,
+                newKey: 'test_id',
+                batchKey: 'test_ids',
+            },
+            ['a', 'b'],
+        ),
+    ).toBe(`\{|
+            ...$Diff<        $Call<
+            ExtractArg,
+            [$PropertyType<$PropertyType<ResourcesType, 'a'>, 'b'>]
+        >, {
+                test_ids: $PropertyType<        $Call<
+            ExtractArg,
+            [$PropertyType<$PropertyType<ResourcesType, 'a'>, 'b'>]
+        >, 'test_ids'>
+            }>,
+            ...{| test_id: $NonMaybeType<$ElementType<$PropertyType<        $Call<
+            ExtractArg,
+            [$PropertyType<$PropertyType<ResourcesType, 'a'>, 'b'>]
+        >, 'test_ids'>, 0>> |}
+        |}`);
 });

--- a/__tests__/implementation.test.js
+++ b/__tests__/implementation.test.js
@@ -130,7 +130,7 @@ test('batch endpoint', async () => {
     });
 });
 
-test("batch endpoint can' be called with null", async () => {
+test("batch endpoint can't be called with null", async () => {
     const config = {
         resources: {
             foo: {

--- a/__tests__/implementation.test.js
+++ b/__tests__/implementation.test.js
@@ -130,6 +130,34 @@ test('batch endpoint', async () => {
     });
 });
 
+test("batch endpoint can' be called with null", async () => {
+    const config = {
+        resources: {
+            foo: {
+                isBatchResource: true,
+                docsLink: 'example.com/docs/bar',
+                batchKey: 'foo_ids',
+                newKey: 'foo_id',
+            },
+        },
+    };
+
+    const resources = {
+        foo: ({ foo_ids }) => {
+            expect(foo_ids).toEqual([1]);
+            return Promise.resolve([{ foo_id: 1, foo_value: 'hello' }]);
+        },
+    };
+
+    await createDataLoaders(config, async (getLoaders) => {
+        const loaders = getLoaders(resources);
+
+        expect(() => {
+            loaders.foo.load(null);
+        }).toThrow(TypeError);
+    });
+});
+
 test('batch endpoint (with reorderResultsByKey)', async () => {
     const config = {
         resources: {

--- a/src/genTypeFlow.ts
+++ b/src/genTypeFlow.ts
@@ -55,7 +55,8 @@ export function getLoaderTypeKey(resourceConfig: ResourceConfig, resourcePath: R
 
     if (resourceConfig.isBatchResource) {
         // Extract newKeyType from the batch key's Array's type
-        let newKeyType = `${resourceConfig.newKey}: $ElementType<$PropertyType<${resourceArgs}, '${resourceConfig.batchKey}'>, 0>`;
+        // We add NonMaybeType before batch key element type to force the batch key to be required, regardless if the OpenAPI spec specifies it as being optional
+        let newKeyType = `${resourceConfig.newKey}: $NonMaybeType<$ElementType<$PropertyType<${resourceArgs}, '${resourceConfig.batchKey}'>, 0>>`;
 
         if (resourceConfig.isBatchKeyASet) {
             /**


### PR DESCRIPTION
Forces a `batchKey` to be non-nullable since we would expect to call graphql with these keys.

This should fix #192. 

Tests pass locally
```
venv/bin/pre-commit run --all-files
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for added large files..............................................Passed
Check JSON...............................................................Passed
Check Yaml...............................................................Passed
prettier.................................................................Passed
Detect secrets...........................................................Passed
yarn test
yarn run v1.22.17
$ jest
 PASS  __tests__/genTypeFlow.test.js
 PASS  __tests__/runtimeHelpers.test.js
 PASS  __tests__/implementation.test.js
  ● Console

    console.warn node_modules/browserslist/node.js:317
      Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`

-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |   96.51 |    93.33 |   93.85 |   96.97 |
 assert.ts         |      50 |       50 |     100 |      50 | 14
 codegen.ts        |     100 |      100 |     100 |     100 |
 genTypeFlow.ts    |   88.37 |       80 |   78.95 |      90 | 6,172-174
 implementation.ts |     100 |      100 |     100 |     100 |
 runtimeHelpers.ts |     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|-------------------

Test Suites: 3 passed, 3 total
Tests:       31 passed, 31 total
Snapshots:   0 total
Time:        3.426s, estimated 4s
Ran all test suites.
✨  Done in 4.01s.
```