### PR TITLE
Fixes ordering of $NonMaybeType so it affects the batch property and not the element

### DIFF
--- a/__tests__/genTypeFlow.test.js
+++ b/__tests__/genTypeFlow.test.js
@@ -39,9 +39,9 @@ it('getLoaderTypeKey forces a nullable batchKey to be strictly non-nullable', ()
             [$PropertyType<$PropertyType<ResourcesType, 'a'>, 'b'>]
         >, 'test_ids'>
             }>,
-            ...{| test_id: $NonMaybeType<$ElementType<$PropertyType<        $Call<
+            ...{| test_id: $ElementType<$NonMaybeType<$PropertyType<        $Call<
             ExtractArg,
             [$PropertyType<$PropertyType<ResourcesType, 'a'>, 'b'>]
-        >, 'test_ids'>, 0>> |}
+        >, 'test_ids'>>, 0> |}
         |}`);
 });

--- a/src/genTypeFlow.ts
+++ b/src/genTypeFlow.ts
@@ -56,7 +56,7 @@ export function getLoaderTypeKey(resourceConfig: ResourceConfig, resourcePath: R
     if (resourceConfig.isBatchResource) {
         // Extract newKeyType from the batch key's Array's type
         // We add NonMaybeType before batch key element type to force the batch key to be required, regardless if the OpenAPI spec specifies it as being optional
-        let newKeyType = `${resourceConfig.newKey}: $NonMaybeType<$ElementType<$PropertyType<${resourceArgs}, '${resourceConfig.batchKey}'>, 0>>`;
+        let newKeyType = `${resourceConfig.newKey}: $ElementType<$NonMaybeType<$PropertyType<${resourceArgs}, '${resourceConfig.batchKey}'>>, 0>`;
 
         if (resourceConfig.isBatchKeyASet) {
             /**


### PR DESCRIPTION
The $NonMaybeType should be placed at the property type for the batch key, not the entire element type.