### PR TITLE
Fix Set key type for isBatchKeyASet + ts-reset

### DIFF
--- a/__tests__/genType.test.js
+++ b/__tests__/genType.test.js
@@ -6,7 +6,7 @@ it('getResourceTypeReference converts a resource path to a valid reference', () 
 
 it('getNewKeyTypeFromBatchKeySetType returns a newKey type with a valid value', () => {
     expect(getNewKeyTypeFromBatchKeySetType('bKey', "ResourcesType['foo']['bar']['baz']")).toBe(
-        `Parameters<ResourcesType['foo']['bar']['baz']['bKey']['has']>[0]`,
+        `GetSetType<ResourcesType['foo']['bar']['baz']['bKey']>`,
     );
 });
 

--- a/examples/swapi/swapi-loaders.ts
+++ b/examples/swapi/swapi-loaders.ts
@@ -55,6 +55,8 @@ export type DataLoaderCodegenOptions = {
   };
 };
 
+type GetSetType<T> = T extends Set<infer U> ? U : never;
+
 /**
  * ===============================
  * BEGIN: printResourcesType()
@@ -101,9 +103,7 @@ export type LoadersType = Readonly<{
   >;
   getFilms: DataLoader<
     Omit<Parameters<ResourcesType["getFilms"]>[0], "film_ids"> & {
-      film_id: Parameters<
-        Parameters<ResourcesType["getFilms"]>[0]["film_ids"]["has"]
-      >[0];
+      film_id: GetSetType<Parameters<ResourcesType["getFilms"]>[0]["film_ids"]>;
     },
     PromisedReturnType<ResourcesType["getFilms"]>[0],
     // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".
@@ -905,9 +905,9 @@ export default function getLoaders(
     ),
     getFilms: new DataLoader<
       Omit<Parameters<ResourcesType["getFilms"]>[0], "film_ids"> & {
-        film_id: Parameters<
-          Parameters<ResourcesType["getFilms"]>[0]["film_ids"]["has"]
-        >[0];
+        film_id: GetSetType<
+          Parameters<ResourcesType["getFilms"]>[0]["film_ids"]
+        >;
       },
       PromisedReturnType<ResourcesType["getFilms"]>[0],
       // This third argument is the cache key type. Since we use objectHash in cacheKeyOptions, this is "string".

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -97,6 +97,8 @@ export default function codegen(
             };
         };
 
+        type GetSetType<T> = T extends Set<infer U> ? U : never;
+
         /**
          * ===============================
          * BEGIN: printResourcesType()

--- a/src/genType.ts
+++ b/src/genType.ts
@@ -15,11 +15,10 @@ function getResourceArg(resourceConfig: ResourceConfig, resourcePath: ReadonlyAr
 }
 
 /**
- * Extract the type T from a Set<T> resource (in this case a batchKey's resource)
- * using its `.has(T)`'s function paremeter type
+ * Extract the type T from a Set<T> resource (using the helper defined in codegen.ts)
  */
 export function getNewKeyTypeFromBatchKeySetType(batchKey: string, resourceArgs: string) {
-    return `Parameters<${resourceArgs}['${batchKey}']['has']>[0]`;
+    return `GetSetType<${resourceArgs}['${batchKey}']>`;
 }
 
 export function getLoaderTypeKey(resourceConfig: ResourceConfig, resourcePath: ReadonlyArray<string>) {


### PR DESCRIPTION
Following the release of TypeScript types in https://github.com/Yelp/dataloader-codegen/pull/355 there is one single error remaining in our internal service. It looks like TypeScript + [ts-reset](https://www.totaltypescript.com/ts-reset) does not infer a string union type when using the `getNewKeyTypeFromBatchKeySetType` helper, according to this rule:

> Make Set.has() less strict

```
src/graphql/dataloaders/__codegen__/foo_loaders.ts:x:y - error TS2345: Argument of type '{ foo: Set<string>; }' is not assignable to parameter of type 'Readonly<{ foo: Set<"BAR" | "BAZ">; }>'.
  Types of property 'foo' are incompatible.
    Type 'Set<string>' is not assignable to type 'Set<"BAR" | "BAZ">'.
      Type 'string' is not assignable to type '"BAR" | "BAZ"'.

1050                       ...__resourceArgs,
                           ~~~~~~~~~~~~~~~~~
```

Because of the reset override, TypeScript infers the parameter type of `Set.prototype.has` to be a `string`, rather than the generic type of the `Set`.

We can fix this by using a type inference instead, `T extends Set<infer U> ? U : never;`. This is arguably the more "correct" way to do it anyway.

----

After linking in the patched dataloader-codegen we no longer have any type errors in our dataloaders. I did not add a regression test as this is specific to users of `ts-reset` and the existing coverage from `testExampleTypes/swapi.ts` should cover the happy path.